### PR TITLE
Removing enforced equality of data and opts.tasks

### DIFF
--- a/omnigan/data.py
+++ b/omnigan/data.py
@@ -185,7 +185,6 @@ class OmniListDataset(Dataset):
         exist on the file-system
         """
         for s in self.samples_paths:
-            assert all([t in s for t in self.tasks])
             for k, v in s.items():
                 assert Path(v).exists(), f"{k} {v} does not exist"
 


### PR DESCRIPTION
I don't think the relevant line in the "check_sample" function is what we want.

 It enforces that the specified tasks are all in the samples. Some specified task might now have an equivalent sample (like 't' --> translation; there is no "sample" that corresponds to translation, but we may still want to specify it as a task).

Also, the "filter_samples()" function does enforces a weaker version of this, and there is a test case in "test_data.py" that ensures it is working properly

