### PR TITLE
fix deeplab encoder parameters + add number of params print in test

### DIFF
--- a/omnigan/encoder.py
+++ b/omnigan/encoder.py
@@ -67,7 +67,9 @@ class DeeplabEncoder(nn.Module):
         """
         super().__init__()
 
-        self.model = ResNetMulti(Bottleneck, opts.gen.deeplabv2.nblocks)
+        self.model = ResNetMulti(
+            Bottleneck, opts.gen.deeplabv2.nblocks, opts.gen.default.n_res
+        )
         if opts.gen.deeplabv2.use_pretrained:
             saved_state_dict = torch.load(opts.gen.deeplabv2.pretrained_model)
             print("Load pretrained Deeplab model")

--- a/tests/test_gen.py
+++ b/tests/test_gen.py
@@ -9,6 +9,7 @@ import torch
 sys.path.append(str(Path(__file__).parent.parent.resolve()))
 from omnigan.generator import get_gen
 from omnigan.utils import load_test_opts
+from omnigan.tutils import get_num_params
 from run import print_header
 
 
@@ -74,7 +75,8 @@ if __name__ == "__main__":
     # ------------------------------------
     if test_encoder:
         print_header("test_encoder")
-        
+        num_params = get_num_params(G.encoder)
+        print("Number of parameters in encoder : {}".format(num_params))
         encoded = G.encode(image)
         print("Latent space dims {}".format(tuple(encoded.shape)[1:]))
 


### PR DESCRIPTION
number of resblocks parameter wasn't propagating correctly in the code...

(it's a teeny-tiny pull request, but then we can keep track of where this problem came from) 