### PR TITLE
Projection layer at front of decoders and classifier

### DIFF
--- a/omnigan/blocks.py
+++ b/omnigan/blocks.py
@@ -240,7 +240,7 @@ class BaseDecoder(nn.Module):
         n_upsample=4,
         n_res=4,
         input_dim=2048,
-        dim=64,
+        proj_dim=64,
         output_dim=3,
         res_norm="instance",
         activ="relu",
@@ -249,10 +249,11 @@ class BaseDecoder(nn.Module):
     ):
         super().__init__()
         self.model = [
-            Conv2dBlock(input_dim, dim, 3, 1, 1, norm=res_norm, activation=activ)
+            Conv2dBlock(input_dim, proj_dim, 3, 1, 1, norm=res_norm, activation=activ)
         ]
 
-        self.model += [ResBlocks(n_res, dim, res_norm, activ, pad_type=pad_type)]
+        self.model += [ResBlocks(n_res, proj_dim, res_norm, activ, pad_type=pad_type)]
+        dim = proj_dim
         # upsampling blocks
         for i in range(n_upsample):
             self.model += [

--- a/omnigan/blocks.py
+++ b/omnigan/blocks.py
@@ -239,6 +239,7 @@ class BaseDecoder(nn.Module):
         self,
         n_upsample=4,
         n_res=4,
+        input_dim=2048,
         dim=64,
         output_dim=3,
         res_norm="instance",
@@ -247,8 +248,11 @@ class BaseDecoder(nn.Module):
         output_activ="tanh",
     ):
         super().__init__()
+        self.model = [
+            Conv2dBlock(input_dim, dim, 3, 1, 1, norm=res_norm, activation=activ)
+        ]
 
-        self.model = [ResBlocks(n_res, dim, res_norm, activ, pad_type=pad_type)]
+        self.model += [ResBlocks(n_res, dim, res_norm, activ, pad_type=pad_type)]
         # upsampling blocks
         for i in range(n_upsample):
             self.model += [

--- a/omnigan/classifier.py
+++ b/omnigan/classifier.py
@@ -6,7 +6,7 @@ from omnigan.blocks import Conv2dBlock
 
 
 def get_classifier(opts, latent_space, verbose):
-    C = OmniClassifier(latent_space, opts.classifier.dim, opts.classifier.loss)
+    C = OmniClassifier(latent_space, opts.classifier.proj_dim, opts.classifier.loss)
     init_weights(
         C,
         init_type=opts.classifier.init_type,
@@ -17,12 +17,13 @@ def get_classifier(opts, latent_space, verbose):
 
 
 class OmniClassifier(nn.Module):
-    def __init__(self, latent_space, dim, loss):
+    def __init__(self, latent_space, proj_dim, loss):
         super(OmniClassifier, self).__init__()
         assert len(latent_space) == 3
         self.channels = latent_space[0]
         self.feature_size = latent_space[1]
         self.loss = loss
+        dim = proj_dim
         self.model = nn.Sequential(
             *[
                 Conv2dBlock(self.channels, dim, 3, 1, 1),

--- a/omnigan/classifier.py
+++ b/omnigan/classifier.py
@@ -23,18 +23,17 @@ class OmniClassifier(nn.Module):
         self.channels = latent_space[0]
         self.feature_size = latent_space[1]
         self.loss = loss
-        dim = proj_dim
         self.model = nn.Sequential(
             *[
-                Conv2dBlock(self.channels, dim, 3, 1, 1),
+                Conv2dBlock(self.channels, proj_dim, 3, 1, 1),
                 nn.MaxPool2d(2),
-                BasicBlock(dim, int(dim / 2), True),
+                BasicBlock(proj_dim, int(proj_dim / 2), True),
                 nn.MaxPool2d(2),
-                BasicBlock(int(dim / 2), int(dim / 4), True),
+                BasicBlock(int(proj_dim / 2), int(proj_dim / 4), True),
                 nn.AvgPool2d((int(self.feature_size / 4), int(self.feature_size / 4))),
                 Squeeze(-1),
                 Squeeze(-1),
-                nn.Linear(int(dim / 4), 2),
+                nn.Linear(int(proj_dim / 4), 2),
             ]
         )
 

--- a/omnigan/encoder.py
+++ b/omnigan/encoder.py
@@ -68,7 +68,7 @@ class DeeplabEncoder(nn.Module):
         super().__init__()
 
         self.model = ResNetMulti(
-            Bottleneck, opts.gen.deeplabv2.nblocks, opts.gen.default.n_res
+            Bottleneck, opts.gen.deeplabv2.nblocks, opts.gen.encoder.n_res
         )
         if opts.gen.deeplabv2.use_pretrained:
             saved_state_dict = torch.load(opts.gen.deeplabv2.pretrained_model)

--- a/omnigan/generator.py
+++ b/omnigan/generator.py
@@ -202,7 +202,7 @@ class MaskDecoder(BaseDecoder):
             n_upsample=opts.gen.m.n_upsample,
             n_res=opts.gen.m.n_res,
             input_dim=opts.gen.encoder.res_dim,
-            dim=opts.gen.m.res_dim,
+            proj_dim=opts.gen.m.proj_dim,
             output_dim=opts.gen.m.output_dim,
             res_norm=opts.gen.m.res_norm,
             activ=opts.gen.m.activ,

--- a/omnigan/generator.py
+++ b/omnigan/generator.py
@@ -229,7 +229,7 @@ class SegmentationDecoder(BaseDecoder):
         super().__init__(
             opts.gen.s.n_upsample,
             opts.gen.s.n_res,
-            dim=opts.gen.s.res_dim,
+            proj_dim=opts.gen.s.proj_dim,
             output_dim=opts.gen.s.output_dim,
             res_norm=opts.gen.s.res_norm,
             activ=opts.gen.s.activ,

--- a/omnigan/generator.py
+++ b/omnigan/generator.py
@@ -199,10 +199,11 @@ class HeightDecoder(BaseDecoder):
 class MaskDecoder(BaseDecoder):
     def __init__(self, opts):
         super().__init__(
-            opts.gen.m.n_upsample,
-            opts.gen.m.n_res,
-            opts.gen.m.res_dim,
-            opts.gen.m.output_dim,
+            n_upsample=opts.gen.m.n_upsample,
+            n_res=opts.gen.m.n_res,
+            input_dim=opts.gen.encoder.res_dim,
+            dim=opts.gen.m.res_dim,
+            output_dim=opts.gen.m.output_dim,
             res_norm=opts.gen.m.res_norm,
             activ=opts.gen.m.activ,
             pad_type=opts.gen.m.pad_type,
@@ -228,8 +229,8 @@ class SegmentationDecoder(BaseDecoder):
         super().__init__(
             opts.gen.s.n_upsample,
             opts.gen.s.n_res,
-            opts.gen.s.res_dim,
-            opts.gen.s.output_dim,
+            dim=opts.gen.s.res_dim,
+            output_dim=opts.gen.s.output_dim,
             res_norm=opts.gen.s.res_norm,
             activ=opts.gen.s.activ,
             pad_type=opts.gen.s.pad_type,

--- a/omnigan/losses.py
+++ b/omnigan/losses.py
@@ -261,7 +261,10 @@ def get_losses(opts, verbose):
     if "w" in opts.tasks:
         losses["G"]["tasks"]["w"] = lambda x, y: (x + y).mean()
     if "m" in opts.tasks:
-        losses["G"]["tasks"]["m"] = nn.BCELoss()
+        losses["G"]["tasks"]["m"] = {}
+        losses["G"]["tasks"]["m"]["main"] = nn.BCELoss()
+        losses["G"]["tasks"]["m"]["tv"] = TVLoss(opts.train.lambdas.G.m.tv)
+
     # undistinguishable features loss
     # TODO setup a get_losses func to assign the right loss according to the yaml
     if opts.classifier.loss == "l1":
@@ -270,17 +273,15 @@ def get_losses(opts, verbose):
         loss_classifier = MSELoss()
     else:
         loss_classifier = CrossEntropy()
-    losses["G"]["classifier"] = loss_classifier 
+    losses["G"]["classifier"] = loss_classifier
     # -------------------------------
     # -----  Classifier Losses  -----
     # -------------------------------
-    losses["C"] = loss_classifier   
+    losses["C"] = loss_classifier
     # ----------------------------------
     # -----  Discriminator Losses  -----
     # ----------------------------------
     losses["D"] = GANLoss(
-        soft_shift=opts.dis.soft_shift,
-        flip_prob=opts.dis.flip_prob,
-        verbose=verbose,
-    )   
+        soft_shift=opts.dis.soft_shift, flip_prob=opts.dis.flip_prob, verbose=verbose,
+    )
     return losses

--- a/omnigan/trainer.py
+++ b/omnigan/trainer.py
@@ -172,7 +172,13 @@ class Trainer:
         self.P = {"s": get_mega_model()}  # P => pseudo labeling models
 
         self.g_opt, self.g_scheduler = get_optimizer(self.G, self.opts.gen.opt)
-         
+
+        print("---------------------------")
+        print("num params encoder: ", get_num_params(self.G.encoder))
+        print("num params decoder: ", get_num_params(self.G.decoders["m"]))
+        print("num params classif: ", get_num_params(self.C))
+        print("---------------------------")
+
         if get_num_params(self.D) > 0:
             self.d_opt, self.d_scheduler = get_optimizer(self.D, self.opts.dis.opt)
         else:

--- a/shared/trainer/defaults.yaml
+++ b/shared/trainer/defaults.yaml
@@ -57,7 +57,7 @@ gen:
     n_downsample: &n_downsample 3 # number of downsampling layers in encoder | dim 32 + down 3 => z = 256 x 32 x 32
     n_upsample: *n_downsample # upsampling in spade decoder ; should match encoder.n_downsample
     pad_type: reflect # padding type [zero/reflect]
-    res_dim: 256 # Resblock number of channels (=latent space's), should be 2048 if using deeplabv2
+    res_dim: 2048 # Resblock number of channels (=latent space's), should be 2048 if using deeplabv2
     res_norm: instance # ResBlock normalization ; one of {"batch", "instance", "layer", "adain", "spectral", "none"}
   encoder: # specific params for the encoder
     <<: *default-gen
@@ -148,6 +148,7 @@ classifier:
   dropout: 0.4 # probability of being set to 0
   init_type: kaiming
   init_gain: 0.2
+  dim: 128
 
 # ------------------------
 # ----- Train Params -----

--- a/shared/trainer/defaults.yaml
+++ b/shared/trainer/defaults.yaml
@@ -58,11 +58,10 @@ gen:
     n_upsample: *n_downsample # upsampling in spade decoder ; should match encoder.n_downsample
     pad_type: reflect # padding type [zero/reflect]
     res_dim: 2048 # Resblock number of channels (=latent space's), should be 2048 if using deeplabv2
-    res_norm: instance # ResBlock normalization ; one of {"batch", "instance", "layer", "adain", "spectral", "none"}
+    res_norm: spectral # ResBlock normalization ; one of {"batch", "instance", "layer", "adain", "spectral", "none"}
+    proj_dim: 64 # Dim of projection from latent space
   encoder: # specific params for the encoder
     <<: *default-gen
-    
-    dim: 32 # dimension of the first projection before downsamplings
     input_dim: 3 # input number of channels
     n_res: 4 # number of residual blocks in content encoder/decoder
     norm: spectral # ConvBlock normalization ; one of {"batch", "instance", "layer", "adain", "spectral", "none"}
@@ -148,7 +147,7 @@ classifier:
   dropout: 0.4 # probability of being set to 0
   init_type: kaiming
   init_gain: 0.2
-  dim: 128
+  proj_dim: 128 #Dim of projection from latent space
 
 # ------------------------
 # ----- Train Params -----


### PR DESCRIPTION
The pretrained encoder gives us a very large latent space (dim=2048), which results in way too many parameters in the decoders and feature-classifier (even without resblocks). To solve this we can learn a projection at each decoder to reduce the dimensionality.