### PR TITLE
Cleanup basedecoder call

### DIFF
--- a/omnigan/deeplabv2.py
+++ b/omnigan/deeplabv2.py
@@ -134,4 +134,3 @@ class ResNetMulti(nn.Module):
         x = self.layer4(x)
         x = self.layer_res(x)
         return x
-

--- a/omnigan/generator.py
+++ b/omnigan/generator.py
@@ -185,10 +185,11 @@ class OmniGenerator(nn.Module):
 class HeightDecoder(BaseDecoder):
     def __init__(self, opts):
         super().__init__(
-            opts.gen.h.n_upsample,
-            opts.gen.h.n_res,
-            opts.gen.h.res_dim,
-            opts.gen.h.output_dim,
+            n_upsample=opts.gen.h.n_upsample,
+            n_res=opts.gen.h.n_res,
+            input_dim=opts.gen.encoder.res_dim,
+            proj_dim=opts.gen.h.proj_dim,
+            output_dim=opts.gen.h.output_dim,
             res_norm=opts.gen.h.res_norm,
             activ=opts.gen.h.activ,
             pad_type=opts.gen.h.pad_type,
@@ -214,39 +215,45 @@ class MaskDecoder(BaseDecoder):
 class DepthDecoder(BaseDecoder):
     def __init__(self, opts):
         super().__init__(
-            opts.gen.d.n_upsample,
-            opts.gen.d.n_res,
-            opts.gen.d.res_dim,
-            opts.gen.d.output_dim,
+            n_upsample=opts.gen.d.n_upsample,
+            n_res=opts.gen.d.n_res,
+            input_dim=opts.gen.encoder.res_dim,
+            proj_dim=opts.gen.d.proj_dim,
+            output_dim=opts.gen.d.output_dim,
             res_norm=opts.gen.d.res_norm,
             activ=opts.gen.d.activ,
             pad_type=opts.gen.d.pad_type,
+            output_activ="sigmoid",
         )
 
 
 class SegmentationDecoder(BaseDecoder):
     def __init__(self, opts):
         super().__init__(
-            opts.gen.s.n_upsample,
-            opts.gen.s.n_res,
+            n_upsample=opts.gen.s.n_upsample,
+            n_res=opts.gen.s.n_res,
+            input_dim=opts.gen.encoder.res_dim,
             proj_dim=opts.gen.s.proj_dim,
             output_dim=opts.gen.s.output_dim,
             res_norm=opts.gen.s.res_norm,
             activ=opts.gen.s.activ,
             pad_type=opts.gen.s.pad_type,
+            output_activ="sigmoid",
         )
 
 
 class AdaptationDecoder(BaseDecoder):
     def __init__(self, opts):
         super().__init__(
-            opts.gen.a.n_upsample,
-            opts.gen.a.n_res,
-            opts.gen.a.res_dim,
-            opts.gen.a.output_dim,
+            n_upsample=opts.gen.a.n_upsample,
+            n_res=opts.gen.a.n_res,
+            input_dim=opts.gen.encoder.res_dim,
+            proj_dim=opts.gen.a.proj_dim,
+            output_dim=opts.gen.a.output_dim,
             res_norm=opts.gen.a.res_norm,
             activ=opts.gen.a.activ,
             pad_type=opts.gen.a.pad_type,
+            output_activ="sigmoid",
         )
 
     def forward(self, z, cond=None):
@@ -256,13 +263,15 @@ class AdaptationDecoder(BaseDecoder):
 class BaseTranslationDecoder(BaseDecoder):
     def __init__(self, opts):
         super().__init__(
-            opts.gen.t.n_upsample,
-            opts.gen.t.n_res,
-            opts.gen.t.res_dim,
-            opts.gen.t.output_dim,
+            n_upsample=opts.gen.t.n_upsample,
+            n_res=opts.gen.t.n_res,
+            input_dim=opts.gen.encoder.res_dim,
+            proj_dim=opts.gen.t.proj_dim,
+            output_dim=opts.gen.t.output_dim,
             res_norm=opts.gen.t.res_norm,
             activ=opts.gen.t.activ,
             pad_type=opts.gen.t.pad_type,
+            output_activ="sigmoid",
         )
 
     def forward(self, z, cond=None):

--- a/omnigan/mega_depth/models/HG_model.py
+++ b/omnigan/mega_depth/models/HG_model.py
@@ -156,4 +156,3 @@ class HGModel(BaseModel):
 
     def switch_to_eval(self):
         self.netG.eval()
-

--- a/omnigan/mega_depth/models/models.py
+++ b/omnigan/mega_depth/models/models.py
@@ -1,7 +1,7 @@
-
 def create_model(opt):
     model = None
     from .HG_model import HGModel
+
     model = HGModel(opt)
     print("model [%s] was created" % (model.name()))
     return model

--- a/omnigan/norms.py
+++ b/omnigan/norms.py
@@ -184,4 +184,3 @@ class SPADE(nn.Module):
         out = normalized * (1 + gamma) + beta
 
         return out
-

--- a/omnigan/strings.py
+++ b/omnigan/strings.py
@@ -36,7 +36,9 @@ def encoder(E):
 
 
 def get_conv_weight(conv):
-    weight = torch.Tensor(conv.out_channels, conv.in_channels // conv.groups, *conv.kernel_size)
+    weight = torch.Tensor(
+        conv.out_channels, conv.in_channels // conv.groups, *conv.kernel_size
+    )
     return weight.shape
 
 

--- a/shared/trainer/defaults.yaml
+++ b/shared/trainer/defaults.yaml
@@ -61,16 +61,17 @@ gen:
     proj_dim: 64 # Dim of projection from latent space
   encoder: # specific params for the encoder
     <<: *default-gen
-    architecture: deeplabv2  #[deeplabv2 (res_dim = 2048) | base (res_dim = 256)] 
+    dim: 32
+    architecture: deeplabv2 # [deeplabv2 (res_dim = 2048) | base (res_dim = 256)]
     input_dim: 3 # input number of channels
-    n_res: 0 # number of residual blocks in content encoder/decoder
+    n_res: 1 # number of residual blocks in content encoder/decoder
     norm: spectral # ConvBlock normalization ; one of {"batch", "instance", "layer", "adain", "spectral", "none"}
 
-  #! Don't change!!!    
-  deeplabv2: 
+  #! Don't change!!!
+  deeplabv2:
     nblocks: [3, 4, 23, 3]
     use_pretrained: True
-    pretrained_model: '/network/tmp1/ccai/data/omnigan/pretrained_models/DeepLab_resnet_pretrained_imagenet.pth'
+    pretrained_model: "/network/tmp1/ccai/data/omnigan/pretrained_models/DeepLab_resnet_pretrained_imagenet.pth"
 
   d: # specific params for the depth estimation decoder
     <<: *default-gen
@@ -151,7 +152,7 @@ train:
     G:
       d: 1
       s: 1
-      m: 
+      m:
         main: 1 # Main prediction loss, i.e. GAN or BCE
         tv: 1 # Total variational loss (for smoothing)
       t:


### PR DESCRIPTION
there were missing proj_dim arguments, crippling the depth decoder (I don't know how that worked for @melisandeteng but it's clearly an issue)

Not blaming anyone but if we could call decoders (and other objects) consistently across the code we would be able to catch errors faster :) 