### PR TITLE
Removing 'a', 't', and fixing encoder args

### DIFF
--- a/omnigan/blocks.py
+++ b/omnigan/blocks.py
@@ -249,7 +249,7 @@ class BaseDecoder(nn.Module):
     ):
         super().__init__()
         self.model = [
-            Conv2dBlock(input_dim, proj_dim, 3, 1, 1, norm=res_norm, activation=activ)
+            Conv2dBlock(input_dim, proj_dim, 1, 1, 0, norm=res_norm, activation=activ)
         ]
 
         self.model += [ResBlocks(n_res, proj_dim, res_norm, activ, pad_type=pad_type)]

--- a/omnigan/encoder.py
+++ b/omnigan/encoder.py
@@ -16,7 +16,7 @@ class BaseEncoder(nn.Module):
         """
         super().__init__()
         activ = opts.gen.encoder.activ
-        dim = opts.gen.encoder.dim
+        dim = opts.gen.encoder.proj_dim
         input_dim = opts.gen.encoder.input_dim
         n_downsample = opts.gen.encoder.n_downsample
         n_res = opts.gen.encoder.n_res

--- a/omnigan/encoder.py
+++ b/omnigan/encoder.py
@@ -16,7 +16,7 @@ class BaseEncoder(nn.Module):
         """
         super().__init__()
         activ = opts.gen.encoder.activ
-        dim = opts.gen.encoder.proj_dim
+        dim = opts.gen.encoder.dim
         input_dim = opts.gen.encoder.input_dim
         n_downsample = opts.gen.encoder.n_downsample
         n_res = opts.gen.encoder.n_res

--- a/omnigan/generator.py
+++ b/omnigan/generator.py
@@ -65,28 +65,8 @@ class OmniGenerator(nn.Module):
         self.verbose = verbose
         self.decoders = {}
 
-        if "t" in opts.tasks and not opts.gen.t.ignore:
-            if opts.gen.t.use_bit_conditioning or opts.gen.t.use_spade:
-                self.decoders["t"] = None
-                # call set_translation_decoder(latent_shape, device)
-            else:
-                self.decoders["t"] = nn.ModuleDict(
-                    {
-                        "f": BaseTranslationDecoder(opts),
-                        "n": BaseTranslationDecoder(opts),
-                    }
-                )
-
-        if "a" in opts.tasks and not opts.gen.a.ignore:
-            self.decoders["a"] = nn.ModuleDict(
-                {"r": AdaptationDecoder(opts), "s": AdaptationDecoder(opts)}
-            )
-
         if "d" in opts.tasks and not opts.gen.d.ignore:
             self.decoders["d"] = DepthDecoder(opts)
-
-        if "h" in opts.tasks and not opts.gen.h.ignore:
-            self.decoders["h"] = HeightDecoder(opts)
 
         if "s" in opts.tasks and not opts.gen.s.ignore:
             self.decoders["s"] = SegmentationDecoder(opts)
@@ -96,105 +76,14 @@ class OmniGenerator(nn.Module):
 
         self.decoders = nn.ModuleDict(self.decoders)
 
-    def set_translation_decoder(self, latent_shape, device):
-        if self.opts.gen.t.use_bit_conditioning:
-            if not self.opts.gen.t.use_spade:
-                raise ValueError("cannot have use_bit_conditioning but not use_spade")
-            self.decoders["t"] = SpadeTranslationDict(latent_shape, self.opts)
-            self.decoders["t"] = self.decoders["t"].to(device)
-        elif self.opts.gen.t.use_spade:
-            self.decoders["t"] = nn.ModuleDict(
-                {
-                    "f": SpadeTranslationDecoder(latent_shape, self.opts).to(device),
-                    "n": SpadeTranslationDecoder(latent_shape, self.opts).to(device),
-                }
-            )
-        for k in ["f", "n"]:
-            init_weights(
-                self.decoders["t"][k],
-                init_type=self.opts.gen.t.init_type,
-                init_gain=self.opts.gen.t.init_gain,
-                verbose=self.verbose,
-            )
-        else:
-            pass  # not using spade in anyway: do nothing
-
-    def translate_batch(self, batch, translator="f", z=None):
-        """Computes the translation of the images in a batch, according amongst
-        other things to batch["domain"]
-
-        Args:
-            batch (dict): Batch dict with keys ['data', 'paths', 'domain', 'mode']
-            translator (str, optional): Translation decoder to use. Defaults to "f".
-            z (torch.Tensor, optional): Precomputed z. Defaults to None.
-
-        Returns:
-            torch.Tensor: 4D image tensor
-        """
-        x = batch["data"]["x"]
-        if z is None:
-            z = self.encode(x)
-
-        K = None
-        if self.opts.gen.t.use_spade:
-            task_tensors = self.decode_tasks(z)
-            K = get_conditioning_tensor(x, task_tensors)
-
-        y = self.decoders["t"][translator](z, K)
-        return y
-
-    def decode_tasks(self, z):
-        return {
-            task: self.decoders[task](z)
-            for task in self.opts.tasks
-            if task not in {"t", "a"}
-        }
-
     def encode(self, x):
         return self.encoder.forward(x)
 
-    def forward_x(self, x, translator="f"):
-        """Computes the translation of an image x to `translator`'s domain.
-        Note this function will encode z and decode the necessary conditioning
-        task tensors
-
-        Args:
-            x (torch.Tensor): images to translate
-            translator (str, optional): translation translator to use. Defaults to "f".
-            classifier_probs (list, optional): probabilities of belonging to a domain.
-                Defaults to None.
-
-        Returns:
-            torch.Tensor: translated image
-        """
-        z = self.encode(x)
-        cond = None
-        if self.opts.gen.t.use_spade:
-            task_tensors = self.decode_tasks(z)
-            cond = get_conditioning_tensor(x, task_tensors)
-        y = self.decoders["t"][translator](z, cond)
-        return y
-
-    def forward(self, x, translator="f"):
-        return self.forward_x(x, translator)
+    def forward(self, x):
+        return self.encode(x)
 
     def __str__(self):
         return strings.generator(self)
-
-
-class HeightDecoder(BaseDecoder):
-    def __init__(self, opts):
-        super().__init__(
-            n_upsample=opts.gen.h.n_upsample,
-            n_res=opts.gen.h.n_res,
-            input_dim=opts.gen.encoder.res_dim,
-            proj_dim=opts.gen.h.proj_dim,
-            output_dim=opts.gen.h.output_dim,
-            res_norm=opts.gen.h.res_norm,
-            activ=opts.gen.h.activ,
-            pad_type=opts.gen.h.pad_type,
-            output_activ="sigmoid",
-        )
 
 
 class MaskDecoder(BaseDecoder):
@@ -240,42 +129,6 @@ class SegmentationDecoder(BaseDecoder):
             pad_type=opts.gen.s.pad_type,
             output_activ="sigmoid",
         )
-
-
-class AdaptationDecoder(BaseDecoder):
-    def __init__(self, opts):
-        super().__init__(
-            n_upsample=opts.gen.a.n_upsample,
-            n_res=opts.gen.a.n_res,
-            input_dim=opts.gen.encoder.res_dim,
-            proj_dim=opts.gen.a.proj_dim,
-            output_dim=opts.gen.a.output_dim,
-            res_norm=opts.gen.a.res_norm,
-            activ=opts.gen.a.activ,
-            pad_type=opts.gen.a.pad_type,
-            output_activ="sigmoid",
-        )
-
-    def forward(self, z, cond=None):
-        return self.model(z)
-
-
-class BaseTranslationDecoder(BaseDecoder):
-    def __init__(self, opts):
-        super().__init__(
-            n_upsample=opts.gen.t.n_upsample,
-            n_res=opts.gen.t.n_res,
-            input_dim=opts.gen.encoder.res_dim,
-            proj_dim=opts.gen.t.proj_dim,
-            output_dim=opts.gen.t.output_dim,
-            res_norm=opts.gen.t.res_norm,
-            activ=opts.gen.t.activ,
-            pad_type=opts.gen.t.pad_type,
-            output_activ="sigmoid",
-        )
-
-    def forward(self, z, cond=None):
-        return self.model(z)
 
 
 class SpadeTranslationDict(nn.ModuleDict):

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -41,8 +41,6 @@ if __name__ == "__main__":
     # ------------------------------------
     print(transforms_string(loaders["train"]["r"].dataset.transform))
 
-    sample = ds[0]
-
     batch = Dict(next(iter(loaders["train"]["r"])))
     print("Batch: ", "items, ", " ".join(batch.keys()), "keys")
 
@@ -83,7 +81,9 @@ if __name__ == "__main__":
                 [
                     str(
                         {
-                            k: [(s, t.shape) for s, t in v.items()] if k == "data" else v
+                            k: [(s, t.shape) for s, t in v.items()]
+                            if k == "data"
+                            else v
                             for k, v in m.items()
                             if k != "paths"
                         }

--- a/tests/test_dis.py
+++ b/tests/test_dis.py
@@ -10,7 +10,7 @@ from omnigan.losses import GANLoss
 from omnigan.utils import load_test_opts
 
 parser = argparse.ArgumentParser()
-parser.add_argument("-c", "--config",  default="config/trainer/local_tests.yaml")
+parser.add_argument("-c", "--config", default="config/trainer/local_tests.yaml")
 args = parser.parse_args()
 root = Path(__file__).parent.parent
 opts = load_test_opts(args.config)

--- a/tests/test_gen.py
+++ b/tests/test_gen.py
@@ -60,7 +60,6 @@ if __name__ == "__main__":
         print(sum(p.numel() for p in G.decoders.parameters()))
 
     G = get_gen(opts).to(device)
-    G.set_translation_decoder(latent_space_dims, device)
 
     # -------------------------------
     # -----  Test Architecture  -----
@@ -95,34 +94,4 @@ if __name__ == "__main__":
                         print(dec, d, G.decoders[dec][d](z).shape)
                 else:
                     print(dec, G.decoders[dec](z).shape)
-
-    #! Holding off on translation...
-    """
-    # --------------------------------------------------------------------
-    # -----  Test translation depending on use_bit_conditioning and  -----
-    # -----  use_spade                                               -----
-    # --------------------------------------------------------------------
-    if test_translation:
-        print_header("test_translation use_bit_conditioning")
-        opts.gen.t.use_spade = True
-        opts.gen.t.use_bit_conditioning = True
-        G = get_gen(opts).to(device)
-        z = G.encode(image)
-        G.set_translation_decoder(latent_space_dims, device)
-        print(G.forward(image, translator="f").shape)
-
-        print_header("test_translation use_spade no use_bit_conditioning")
-        opts.gen.t.use_spade = True
-        opts.gen.t.use_bit_conditioning = False
-        G = get_gen(opts).to(device)
-        G.set_translation_decoder(latent_space_dims, device)
-        print(G.forward(image, translator="f").shape)
-
-        print_header("test_translation vanilla")
-        opts.gen.t.use_spade = False
-        opts.gen.t.use_bit_conditioning = False
-        G = get_gen(opts).to(device)
-        G.set_translation_decoder(latent_space_dims, device)
-        print(G.forward(image, translator="f").shape)
-    """
 

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -23,16 +23,17 @@ if __name__ == "__main__":
     trainer.setup()
     multi_batch_tuple = next(iter(trainer.train_loaders))
     multi_domain_batch = {
-        batch["domain"][0]: trainer.batch_to_device(batch) for batch in multi_batch_tuple
+        batch["domain"][0]: trainer.batch_to_device(batch)
+        for batch in multi_batch_tuple
     }
     # -------------------------
     # -----  Test Config  -----
     # -------------------------
-    test_setup = False
-    test_get_representation_loss = False
-    test_get_translation_loss = False
-    test_get_classifier_loss = False
-    test_update_g = False
+    test_setup = True
+    test_get_representation_loss = True
+    test_get_translation_loss = True
+    test_get_classifier_loss = True
+    test_update_g = True
     test_update_d = False
     test_full_step = True
 
@@ -53,7 +54,7 @@ if __name__ == "__main__":
             trainer.setup()
 
         loss = trainer.get_representation_loss(multi_domain_batch)
-        print("Loss {}".format(loss.item()))
+        print("Loss {}".format(loss))
 
     # -------------------------------------------------
     # -----  Test trainer.get_translation_loss()  -----
@@ -65,7 +66,7 @@ if __name__ == "__main__":
             trainer.setup()
 
         loss = trainer.get_translation_loss(multi_domain_batch)
-        print("Loss {}".format(loss.item()))
+        print("Loss {}".format(loss))
 
     # ------------------------------------------------
     # -----  Test trainer.get_classifier_loss()  -----
@@ -131,7 +132,9 @@ if __name__ == "__main__":
         trainer.opts.train.representational_training = False
         trainer.opts.train.representation_steps = 100
         trainer.logger.global_step = 200
-        print(False, 100, 200, "Not Using repr_tr and step < repr_step and step % 2 == 0")
+        print(
+            False, 100, 200, "Not Using repr_tr and step < repr_step and step % 2 == 0"
+        )
         trainer.update_g(multi_domain_batch, 1)
         print()
 
@@ -139,7 +142,9 @@ if __name__ == "__main__":
         trainer.opts.train.representational_training = False
         trainer.opts.train.representation_steps = 100
         trainer.logger.global_step = 201
-        print(False, 100, 201, "Not Using repr_tr and step > repr_step and step % 2 == 1")
+        print(
+            False, 100, 201, "Not Using repr_tr and step > repr_step and step % 2 == 1"
+        )
         trainer.update_g(multi_domain_batch, 1)
         print()
 
@@ -169,6 +174,7 @@ if __name__ == "__main__":
     # -----  Test full update step  -----
     # -----------------------------------
     if test_full_step:
+        trainer.logger.global_step = 0
         trainer.verbose = 0
         trainer.losses["D"].verbose = 0
         print_header("test FULL STEP")
@@ -176,7 +182,9 @@ if __name__ == "__main__":
             print("Setting up")
             trainer.setup()
 
-        encoder_weights = [[p.detach().cpu().numpy()[:5] for p in trainer.G.encoder.parameters()]]
+        encoder_weights = [
+            [p.detach().cpu().numpy()[:5] for p in trainer.G.encoder.parameters()]
+        ]
 
         print("First update: extrapolation")
         print("  - Update g")
@@ -202,7 +210,9 @@ if __name__ == "__main__":
         print("Freezing encoder")
         freeze(trainer.G.encoder)
         trainer.representation_is_frozen = True
-        encoder_weights += [[p.cpu().numpy()[:5] for p in trainer.G.encoder.parameters()]]
+        encoder_weights += [
+            [p.cpu().numpy()[:5] for p in trainer.G.encoder.parameters()]
+        ]
         trainer.logger.global_step += 1
 
         print("Third update: extrapolation")
@@ -223,7 +233,9 @@ if __name__ == "__main__":
         print("  - Update c")
         trainer.update_c(multi_domain_batch)
 
-        encoder_weights += [[p.cpu().numpy()[:5] for p in trainer.G.encoder.parameters()]]
+        encoder_weights += [
+            [p.cpu().numpy()[:5] for p in trainer.G.encoder.parameters()]
+        ]
 
         # # ? triggers segmentation fault for some unknown reason
         # # encoder was updated


### PR DESCRIPTION
Doing a bit of cleanup in the generator (to prep for bringing the painter in):

- Removing references to "a" and "t"

- Changing "dim" argument in encoder to "proj_dim" for consistency

Note: all the tests run except for "test_dis.py". This is because right now the model has no discriminators. This can be fixed after we introduce ADVENT or the painter, whatever comes first.