### PR TITLE
Depth head facelift

### DIFF
--- a/omnigan/data.py
+++ b/omnigan/data.py
@@ -119,7 +119,7 @@ def tensor_loader(path, task, domain):
     elif Path(path).suffix == ".npy":
         arr = np.load(path).astype(np.float32)  # .astype(np.uint8)
     elif is_image_file(path):
-        arr = arr = imread(path).astype(np.float32)  # .astype(np.uint8)
+        arr = imread(path).astype(np.float32)  # .astype(np.uint8)
     else:
         raise ValueError("Unknown data type {}".format(path))
 
@@ -130,7 +130,7 @@ def tensor_loader(path, task, domain):
         arr = np.moveaxis(arr, 2, 0)
 
     if task == "m":
-        arr[arr != 0] = 255
+        arr[arr != 0] = 1
         # Make sure mask is single-channel
         if len(arr.shape) >= 3:
             arr = arr[:, :, 0]

--- a/omnigan/data.py
+++ b/omnigan/data.py
@@ -111,15 +111,15 @@ def tensor_loader(path, task, domain):
         if Path(path).suffix == ".npy":
             arr = np.load(path)
         else:
-            arr = arr = imread(path).astype(np.uint8)
+            arr = imread(path)  # .astype(np.uint8)
         arr = torch.from_numpy(arr)
         arr = get_normalized_depth_t(arr, domain, normalize=False)
-        arr = arr.unsqueeze(0).unsqueeze(0)
+        arr = arr.unsqueeze(0)
         return arr
     elif Path(path).suffix == ".npy":
-        arr = np.load(path).astype(np.uint8)
+        arr = np.load(path).astype(np.float32)  # .astype(np.uint8)
     elif is_image_file(path):
-        arr = arr = imread(path).astype(np.uint8)
+        arr = arr = imread(path).astype(np.float32)  # .astype(np.uint8)
     else:
         raise ValueError("Unknown data type {}".format(path))
 

--- a/omnigan/data.py
+++ b/omnigan/data.py
@@ -85,7 +85,7 @@ def pil_image_loader(path, task):
         arr = arr[:, :, 0:3]
 
     if task == "m":
-        arr[arr != 0] = 255
+        arr[arr != 0] = 1
         # Make sure mask is single-channel
         if len(arr.shape) >= 3:
             arr = arr[:, :, 0]
@@ -113,7 +113,7 @@ def tensor_loader(path, task, domain):
         else:
             arr = imread(path)  # .astype(np.uint8)
         arr = torch.from_numpy(arr)
-        arr = get_normalized_depth_t(arr, domain, normalize=False)
+        arr = get_normalized_depth_t(arr, domain, normalize=True)
         arr = arr.unsqueeze(0)
         return arr
     elif Path(path).suffix == ".npy":

--- a/omnigan/data.py
+++ b/omnigan/data.py
@@ -71,7 +71,7 @@ def is_image_file(filename):
     return Path(filename).suffix in IMG_EXTENSIONS
 
 
-def pil_image_loader(path, task, domain):
+def pil_image_loader(path, task):
     if Path(path).suffix == ".npy":
         arr = np.load(path).astype(np.uint8)
     elif is_image_file(path):

--- a/omnigan/losses.py
+++ b/omnigan/losses.py
@@ -226,7 +226,7 @@ class SIMSELoss(nn.Module):
     def __call__(self, prediction, target):
         d = prediction - target
         diff = torch.mean(d * d)
-        relDiff = (d.sum() * d.sum()) / float(d.size * d.size)
+        relDiff = (d.sum() * d.sum()) / float(d.size()[-1] * d.size()[-2])
         return diff - relDiff
 
 

--- a/omnigan/losses.py
+++ b/omnigan/losses.py
@@ -226,7 +226,7 @@ class SIMSELoss(nn.Module):
     def __call__(self, prediction, target):
         d = prediction - target
         diff = torch.mean(d * d)
-        relDiff = (d.sum() * d.sum()) / float(d.size()[-1] * d.size()[-2])
+        relDiff = torch.mean(d) * torch.mean(d)
         return diff - relDiff
 
 

--- a/omnigan/losses.py
+++ b/omnigan/losses.py
@@ -9,6 +9,7 @@ import torch.nn as nn
 from random import random as rand
 from torchvision import models
 
+
 class GANLoss(nn.Module):
     def __init__(
         self,
@@ -235,7 +236,7 @@ class L1Loss(MSELoss):
         super().__init__()
         self.loss = torch.nn.L1Loss()
 
-=
+
 class SIMSELoss(nn.Module):
     """Scale invariant MSE Loss
     """
@@ -248,6 +249,7 @@ class SIMSELoss(nn.Module):
         diff = torch.mean(d * d)
         relDiff = torch.mean(d) * torch.mean(d)
         return diff - relDiff
+
 
 class ContextLoss(nn.Module):
     """

--- a/omnigan/losses.py
+++ b/omnigan/losses.py
@@ -216,6 +216,20 @@ class L1Loss(MSELoss):
         self.loss = torch.nn.L1Loss()
 
 
+class SIMSELoss(nn.Module):
+    """Scale invariant MSE Loss
+    """
+
+    def __init__(self):
+        super(SIMSELoss, self).__init__()
+
+    def __call__(self, prediction, target):
+        d = prediction - target
+        diff = torch.mean(d * d)
+        relDiff = (d.sum() * d.sum()) / float(d.size * d.size)
+        return diff - relDiff
+
+
 ##################################################################################
 # VGG network definition
 ##################################################################################
@@ -309,7 +323,7 @@ def get_losses(opts, verbose, device=None):
     # ? * add discriminator and gan loss to these task when no ground truth
     # ?   instead of noisy label
     if "d" in opts.tasks:
-        losses["G"]["tasks"]["d"] = MSELoss()
+        losses["G"]["tasks"]["d"] = SIMSELoss()
     if "s" in opts.tasks:
         losses["G"]["tasks"]["s"] = CrossEntropy()
     if "m" in opts.tasks:
@@ -335,7 +349,7 @@ def get_losses(opts, verbose, device=None):
     # -----  Discriminator Losses  -----
     # ----------------------------------
     losses["D"]["default"] = GANLoss(
-        soft_shift=opts.dis.soft_shift, flip_prob=opts.dis.flip_prob, verbose=verbose,
+        soft_shift=opts.dis.soft_shift, flip_prob=opts.dis.flip_prob, verbose=verbose
     )
     losses["D"]["advent"] = ADVENTAdversarialLoss(opts)
     return losses

--- a/omnigan/trainer.py
+++ b/omnigan/trainer.py
@@ -26,6 +26,7 @@ from omnigan.tutils import (
     shuffle_batch_tuple,
     vgg_preprocess,
     to_im_depth,
+    norm_tensor,
 )
 from omnigan.utils import div_dict, flatten_opts, sum_dict
 
@@ -413,8 +414,8 @@ class Trainer:
 
                         if update_task in {"d"}:
                             # prediction is a log depth tensor
-                            target = to_im_depth(target) * 255
-                            prediction = to_im_depth(prediction) * 255
+                            target = (norm_tensor(target)) * 255
+                            prediction = (norm_tensor(prediction)) * 255
                             prediction = prediction.repeat(1, 3, 1, 1)
                             task_saves.append(target.repeat(1, 3, 1, 1))
 

--- a/omnigan/trainer.py
+++ b/omnigan/trainer.py
@@ -396,7 +396,6 @@ class Trainer:
         if domain != "rf":
             for im_set in self.display_images[mode][domain]:
                 x = im_set["data"]["x"].unsqueeze(0).to(self.device)
-
                 self.z = self.G.encode(x)
 
                 for update_task, update_target in im_set["data"].items():
@@ -414,8 +413,8 @@ class Trainer:
 
                         if update_task in {"d"}:
                             # prediction is a log depth tensor
-                            target = to_im_depth(target)
-                            prediction = to_im_depth(prediction)
+                            target = to_im_depth(target) * 255
+                            prediction = to_im_depth(prediction) * 255
                             prediction = prediction.repeat(1, 3, 1, 1)
                             task_saves.append(target.repeat(1, 3, 1, 1))
 
@@ -426,6 +425,7 @@ class Trainer:
                             save_images[update_task].append(im)
 
             for task in save_images.keys():
+                print(task)
                 # Write images:
                 self.write_images(
                     image_outputs=save_images[task],

--- a/omnigan/trainer.py
+++ b/omnigan/trainer.py
@@ -25,7 +25,6 @@ from omnigan.tutils import (
     get_num_params,
     shuffle_batch_tuple,
     vgg_preprocess,
-    to_im_depth,
     norm_tensor,
 )
 from omnigan.utils import div_dict, flatten_opts, sum_dict
@@ -402,6 +401,7 @@ class Trainer:
                 for update_task, update_target in im_set["data"].items():
                     target = im_set["data"][update_task].unsqueeze(0).to(self.device)
                     task_saves = []
+
                     if update_task != "x":
                         if update_task not in save_images:
                             save_images[update_task] = []
@@ -418,7 +418,6 @@ class Trainer:
                             prediction = (norm_tensor(prediction)) * 255
                             prediction = prediction.repeat(1, 3, 1, 1)
                             task_saves.append(target.repeat(1, 3, 1, 1))
-
                         task_saves.append(prediction)
                         # ! This assumes the output is some kind of image
                         save_images[update_task].append(x)

--- a/omnigan/transforms.py
+++ b/omnigan/transforms.py
@@ -28,10 +28,6 @@ class Resize:
         self.w = int(self.w)
 
     def __call__(self, data):
-        for task, im in data.items():
-            print(task, im.shape)
-            print(task, im.dtype)
-
         return {
             task: F.interpolate(im, (self.h, self.w), mode=interpolation(task))
             for task, im in data.items()
@@ -110,7 +106,7 @@ class Normalize:
 
     def __call__(self, data):
         return {
-            task: self.normalize.get(task, lambda x: x)(tensor)
+            task: self.normalize.get(task, lambda x: x)(tensor.squeeze(0))
             for task, tensor in data.items()
         }
 

--- a/omnigan/transforms.py
+++ b/omnigan/transforms.py
@@ -94,7 +94,7 @@ class ToTensor:
 class Normalize:
     def __init__(self):
 
-        #self.normImage = trsfs.Normalize(([0.485, 0.456, 0.406], [0.229, 0.224, 0.225]))
+        # self.normImage = trsfs.Normalize(([0.485, 0.456, 0.406], [0.229, 0.224, 0.225]))
         self.normImage = trsfs.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))
         self.normDepth = lambda x: x  # trsfs.Normalize([1 / 255], [1 / 3])
         self.normMask = lambda x: x

--- a/omnigan/transforms.py
+++ b/omnigan/transforms.py
@@ -29,8 +29,8 @@ class Resize:
 
     def __call__(self, data):
         return {
-            task: F.interpolate(im, (self.h, self.w), mode=interpolation(task))
-            for task, im in data.items()
+            task: F.interpolate(tensor, (self.h, self.w), mode=interpolation(task))
+            for task, tensor in data.items()
         }
 
 
@@ -51,7 +51,8 @@ class RandomCrop:
         top = np.random.randint(0, h - self.h)
         left = np.random.randint(0, w - self.w)
         return {
-            task: im[:, top : top + self.h, left + self.w] for task, im in data.items()
+            task: tensor[:, top : top + self.h, left + self.w]
+            for task, tensor in data.items()
         }
 
 
@@ -63,9 +64,9 @@ class RandomHorizontalFlip:
     def __call__(self, data):
         if np.random.rand() > self.p:
             return data
-        for task, im in data.items():
-            print(task, im.shape)
-        return {task: torch.flip(im, (1,)) for task, im in data.items()}
+        for task, tensor in data.items():
+            print(task, tensor.shape)
+        return {task: torch.flip(tensor, (1,)) for task, tensor in data.items()}
 
 
 class ToTensor:
@@ -92,7 +93,7 @@ class ToTensor:
 
 class Normalize:
     def __init__(self):
-        self.normImage = trsfs.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225])
+        self.normImage = trsfs.Normalize([127.5, 127.5, 127.5], [127.5, 127.5, 127.5])
         # self.normSeg = trsfs.Normalize([0.5, 0.5, 0.5], [0.5, 0.5, 0.5])
         self.normDepth = lambda x: x  # trsfs.Normalize([1 / 255], [1 / 3])
         self.normMask = lambda x: x

--- a/omnigan/transforms.py
+++ b/omnigan/transforms.py
@@ -93,8 +93,8 @@ class ToTensor:
 
 class Normalize:
     def __init__(self):
-        self.normImage = trsfs.Normalize([127.5, 127.5, 127.5], [127.5, 127.5, 127.5])
-        # self.normSeg = trsfs.Normalize([0.5, 0.5, 0.5], [0.5, 0.5, 0.5])
+        # self.normImage = trsfs.Normalize([127.5, 127.5, 127.5], [127.5, 127.5, 127.5])
+        self.normImage = trsfs.Normalize([0.5, 0.5, 0.5], [0.5, 0.5, 0.5])
         self.normDepth = lambda x: x  # trsfs.Normalize([1 / 255], [1 / 3])
         self.normMask = lambda x: x
 

--- a/omnigan/transforms.py
+++ b/omnigan/transforms.py
@@ -94,7 +94,7 @@ class ToTensor:
 class Normalize:
     def __init__(self):
         # self.normImage = trsfs.Normalize([127.5, 127.5, 127.5], [127.5, 127.5, 127.5])
-        self.normImage = trsfs.Normalize([0.5, 0.5, 0.5], [0.5, 0.5, 0.5])
+        self.normImage = trsfs.Normalize(([0.485, 0.456, 0.406], [0.229, 0.224, 0.225]))
         self.normDepth = lambda x: x  # trsfs.Normalize([1 / 255], [1 / 3])
         self.normMask = lambda x: x
 

--- a/omnigan/tutils.py
+++ b/omnigan/tutils.py
@@ -198,9 +198,9 @@ def decode_unity_depth_t(unity_depth, log=True, normalize=False, numpy=False, fa
         [torch.Tensor or numpy.array]: decoded depth
     """
     im_array = (unity_depth * 255).type(torch.IntTensor)
-    R = im_array[0, :, :]
-    G = im_array[1, :, :]
-    B = im_array[2, :, :]
+    R = im_array[:, :, 0]
+    G = im_array[:, :, 1]
+    B = im_array[:, :, 2]
 
     R = ((247 - R) / 8).type(torch.FloatTensor)
     G = ((247 - G) / 8).type(torch.FloatTensor)

--- a/omnigan/tutils.py
+++ b/omnigan/tutils.py
@@ -160,6 +160,7 @@ def show_tanh_tensor(tensor):
 def get_normalized_depth_t(arr, domain, normalize=False):
     if domain == "r":
         # megadepth depth
+        arr = arr.unsqueeze(0)
         if normalize:
             arr = arr - torch.min(arr)
             arr /= torch.max(arr)

--- a/omnigan/tutils.py
+++ b/omnigan/tutils.py
@@ -204,7 +204,7 @@ def decode_unity_depth_t(unity_depth, log=True, normalize=False, numpy=False, fa
     Returns:
         [torch.Tensor or numpy.array]: decoded depth
     """
-    im_array = (unity_depth * 255).type(torch.IntTensor)
+    im_array = unity_depth  # * 255).type(torch.IntTensor)
     R = im_array[:, :, 0]
     G = im_array[:, :, 1]
     B = im_array[:, :, 2]
@@ -225,16 +225,16 @@ def decode_unity_depth_t(unity_depth, log=True, normalize=False, numpy=False, fa
     return depth
 
 
-def to_im_depth(log_depth, numpy=False):
+def to_inv_depth(log_depth, numpy=False):
     """Convert log depth tensor to inverse depth image for display
 
     Args:
         depth (Tensor): log depth float tensor
     """
-    # depth = torch.exp(log_depth)
+    depth = torch.exp(log_depth)
     # visualize prediction using inverse depth, so that we don't need sky segmentation (if you want to use RGB map for visualization, \
     # you have to run semantic segmentation to mask the sky first since the depth of sky is random from CNN)
-    inv_depth = 1 / (log_depth + 1e-3)
+    inv_depth = 1 / depth
     inv_depth /= torch.max(inv_depth)
     if numpy:
         inv_depth = inv_depth.data.cpu().numpy()

--- a/omnigan/tutils.py
+++ b/omnigan/tutils.py
@@ -204,10 +204,9 @@ def decode_unity_depth_t(unity_depth, log=True, normalize=False, numpy=False, fa
     Returns:
         [torch.Tensor or numpy.array]: decoded depth
     """
-    im_array = unity_depth  # * 255).type(torch.IntTensor)
-    R = im_array[:, :, 0]
-    G = im_array[:, :, 1]
-    B = im_array[:, :, 2]
+    R = unity_depth[:, :, 0]
+    G = unity_depth[:, :, 1]
+    B = unity_depth[:, :, 2]
 
     R = ((247 - R) / 8).type(torch.FloatTensor)
     G = ((247 - G) / 8).type(torch.FloatTensor)

--- a/omnigan/tutils.py
+++ b/omnigan/tutils.py
@@ -157,16 +157,15 @@ def show_tanh_tensor(tensor):
     skimage.io.imshow(image)
 
 
-def get_normalized_depth_t(arr, domain):
+def get_normalized_depth_t(arr, domain, normalize=False):
     if domain == "r":
         # megadepth depth
-        arr = arr / 255
-        arr[arr != 0] = 1 / arr[arr != 0]
-        arr = arr - torch.min(arr)
-        arr /= torch.max(arr)
+        if normalize:
+            arr = arr - torch.min(arr)
+            arr /= torch.max(arr)
     elif domain == "s":
         # from 3-channel depth encoding from Unity simulator to 1-channel [0-1] values
-        arr = decode_unity_depth_t(arr, log=True, normalize=False)
+        arr = decode_unity_depth_t(arr, log=True, normalize=normalize)
     return arr
 
 
@@ -217,6 +216,24 @@ def decode_unity_depth_t(unity_depth, log=True, normalize=False, numpy=False, fa
         depth = depth.data.cpu().numpy()
         return depth.astype(np.uint8).squeeze()
     return depth
+
+
+def to_im_depth(log_depth, numpy=False):
+    """Convert log depth tensor to inverse depth image for display
+
+    Args:
+        depth (Tensor): log depth float tensor
+    """
+    depth = torch.exp(log_depth)
+    # visualize prediction using inverse depth, so that we don't need sky segmentation (if you want to use RGB map for visualization, \
+    # you have to run semantic segmentation to mask the sky first since the depth of sky is random from CNN)
+    inv_depth = 1 / depth
+    inv_depth /= torch.max(inv_depth)[0]
+    if numpy:
+        inv_depth = inv_depth.data.cpu().numpy()
+    # you might also use percentile for better visualization
+
+    return inv_depth
 
 
 def shuffle_batch_tuple(mbt):

--- a/omnigan/tutils.py
+++ b/omnigan/tutils.py
@@ -166,11 +166,11 @@ def get_normalized_depth_t(arr, domain):
         arr /= torch.max(arr)
     elif domain == "s":
         # from 3-channel depth encoding from Unity simulator to 1-channel [0-1] values
-        arr = decode_unity_depth_t(arr, normalize=True)
+        arr = decode_unity_depth_t(arr, log=True, normalize=False)
     return arr
 
 
-def decode_unity_depth_t(unity_depth, normalize=True, numpy=False, far=1000):
+def decode_unity_depth_t(unity_depth, log=True, normalize=False, numpy=False, far=1000):
     """Transforms the 3-channel encoded depth map from our Unity simulator to 1-channel depth map
     containing metric depth values.
     The depth is encoded in the following way:
@@ -208,6 +208,8 @@ def decode_unity_depth_t(unity_depth, normalize=True, numpy=False, far=1000):
     B = (255 - B).type(torch.FloatTensor)
     depth = ((R * 256 * 31 + G * 256 + B).type(torch.FloatTensor)) / (256 * 31 * 31 - 1)
     depth = (depth * far).unsqueeze(0)
+    if log:
+        depth = torch.log(depth)
     if normalize:
         depth = depth - torch.min(depth)
         depth /= torch.max(depth)

--- a/omnigan/tutils.py
+++ b/omnigan/tutils.py
@@ -157,6 +157,12 @@ def show_tanh_tensor(tensor):
     skimage.io.imshow(image)
 
 
+def norm_tensor(t):
+    t = t - torch.min(t)
+    t /= torch.max(t)
+    return t
+
+
 def get_normalized_depth_t(arr, domain, normalize=False):
     if domain == "r":
         # megadepth depth
@@ -225,10 +231,10 @@ def to_im_depth(log_depth, numpy=False):
     Args:
         depth (Tensor): log depth float tensor
     """
-    depth = torch.exp(log_depth)
+    # depth = torch.exp(log_depth)
     # visualize prediction using inverse depth, so that we don't need sky segmentation (if you want to use RGB map for visualization, \
     # you have to run semantic segmentation to mask the sky first since the depth of sky is random from CNN)
-    inv_depth = 1 / depth
+    inv_depth = 1 / (log_depth + 1e-3)
     inv_depth /= torch.max(inv_depth)
     if numpy:
         inv_depth = inv_depth.data.cpu().numpy()

--- a/omnigan/tutils.py
+++ b/omnigan/tutils.py
@@ -229,7 +229,7 @@ def to_im_depth(log_depth, numpy=False):
     # visualize prediction using inverse depth, so that we don't need sky segmentation (if you want to use RGB map for visualization, \
     # you have to run semantic segmentation to mask the sky first since the depth of sky is random from CNN)
     inv_depth = 1 / depth
-    inv_depth /= torch.max(inv_depth)[0]
+    inv_depth /= torch.max(inv_depth)
     if numpy:
         inv_depth = inv_depth.data.cpu().numpy()
     # you might also use percentile for better visualization

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -5,7 +5,6 @@ from pathlib import Path
 sys.path.append(str(Path(__file__).parent.parent.resolve()))
 from omnigan.trainer import Trainer
 from omnigan.utils import load_test_opts
-from omnigan.tutils import freeze
 from run import print_header
 
 parser = argparse.ArgumentParser()
@@ -207,5 +206,4 @@ if __name__ == "__main__":
         # trainer.update_d(multi_domain_batch)
         print("  - Update c")
         trainer.update_c(multi_domain_batch)
-
 


### PR DESCRIPTION
In this PR, the following changes are made to the depth head: 
- [x]  input depth is a npy array of log depth
- [x] log inverse depth images in comet 
- [x] change loss to scale invariant MSE loss
- [x]  change loader and trasforms so that they can be applied to float tensors
- [x] change image logging 
if you want to check what the inputs would look like, npy arrays of log depth predictions from Megadepth have been saved at `/network/tmp1/ccai/data/munit_dataset/trainA_megadepth_resized`