### PR TITLE
Quick depth fix

### DIFF
--- a/omnigan/tutils.py
+++ b/omnigan/tutils.py
@@ -208,10 +208,12 @@ def decode_unity_depth_t(unity_depth, log=True, normalize=False, numpy=False, fa
     G = unity_depth[:, :, 1]
     B = unity_depth[:, :, 2]
 
-    R = ((247 - R) / 8).type(torch.FloatTensor)
-    G = ((247 - G) / 8).type(torch.FloatTensor)
-    B = (255 - B).type(torch.FloatTensor)
-    depth = ((R * 256 * 31 + G * 256 + B).type(torch.FloatTensor)) / (256 * 31 * 31 - 1)
+    R = ((256.0 - R) / 8.0).type(torch.FloatTensor)
+    G = ((256.0 - G) / 8.0).type(torch.FloatTensor)
+    B = (256.0 - B).type(torch.FloatTensor)
+    depth = ((R * 256.0 * 31.0 + G * 256.0 + B).type(torch.FloatTensor)) / (
+        256.0 * 31.0 * 31.0 - 1.0
+    )
     depth = (depth * far).unsqueeze(0)
     if log:
         depth = torch.log(depth)


### PR DESCRIPTION
Some pixels in the depth maps from simulated world were bringing depth to 0, causing the target image to be all "NaN". So this is a quick fix that solves the problem. (: