### PR TITLE
Pseudo-labels for real domain segmentation

### DIFF
--- a/omnigan/data.py
+++ b/omnigan/data.py
@@ -23,7 +23,7 @@ IMG_EXTENSIONS = set(
 )
 
 classes_dict = {
-    "s": {
+    "s": {  # unity
         0: [0, 0, 255, 255],  # Water
         1: [55, 55, 55, 255],  # Ground
         2: [0, 255, 255, 255],  # Building
@@ -36,7 +36,7 @@ classes_dict = {
         9: [0, 0, 0, 255],  # Sky
         10: [255, 255, 255, 255],  # Default
     },
-    "r": {
+    "r": {  # deeplab v2
         0: [0, 0, 255, 255],  # Water
         1: [55, 55, 55, 255],  # Ground
         2: [0, 255, 255, 255],  # Building
@@ -52,7 +52,7 @@ classes_dict = {
 }
 
 
-def decode_segmap_unity_labels(tensor, domain, is_target, nc=11):
+def decode_segmap_merged_labels(tensor, domain, is_target, nc=11):
     """Creates a label colormap for classes used in Unity segmentation benchmark.
     Arguments:
         tensor -- segmented image of size (1) x (nc) x (H) x (W) if prediction, or size (1) x (1) x (H) x (W) if target

--- a/omnigan/data.py
+++ b/omnigan/data.py
@@ -235,7 +235,7 @@ def tensor_loader(path, task, domain):
     Returns:
         [Tensor]: 1 x C x H x W
     """
-    if task == "s" and domain == "s":
+    if task == "s":
         arr = torch.load(path)
         return arr
     elif task == "d":

--- a/omnigan/trainer.py
+++ b/omnigan/trainer.py
@@ -445,12 +445,11 @@ class Trainer:
                     prediction = self.G.decoders[update_task](self.z)
 
                     if update_task == "s":
-                        if domain == "s":
-                            target = (
-                                decode_segmap_unity_labels(target, domain, True)
-                                .float()
-                                .to(self.device)
-                            )
+                        target = (
+                            decode_segmap_unity_labels(target, domain, True)
+                            .float()
+                            .to(self.device)
+                        )
                         prediction = (
                             decode_segmap_unity_labels(prediction, domain, False)
                             .float()

--- a/omnigan/trainer.py
+++ b/omnigan/trainer.py
@@ -18,7 +18,7 @@ from addict import Dict
 from comet_ml import Experiment
 
 from omnigan.classifier import OmniClassifier, get_classifier
-from omnigan.data import get_all_loaders, decode_segmap_unity_labels
+from omnigan.data import get_all_loaders, decode_segmap_merged_labels
 from omnigan.discriminator import OmniDiscriminator, get_dis
 from omnigan.generator import OmniGenerator, get_gen
 from omnigan.losses import get_losses
@@ -446,12 +446,12 @@ class Trainer:
 
                     if update_task == "s":
                         target = (
-                            decode_segmap_unity_labels(target, domain, True)
+                            decode_segmap_merged_labels(target, domain, True)
                             .float()
                             .to(self.device)
                         )
                         prediction = (
-                            decode_segmap_unity_labels(prediction, domain, False)
+                            decode_segmap_merged_labels(prediction, domain, False)
                             .float()
                             .to(self.device)
                         )


### PR DESCRIPTION
Really small modifications so that we directly load the .pt tensors of the seg maps for the real domain (instead of the .png images), to allow using pseudo-labels for segmentation task.

For now, .json file with .pt extension are in:

- /network/tmp1/ccai/data/omnigan/base/train_r_full_pl.json
- /network/tmp1/ccai/data/omnigan/base/val_r_full_pl.json

When (if) this PR is merged, I will change {train/val}_r_full_pl.json for {train/val}_r_full.json.

Experiment with use_pseudo_labels=true: [here](https://www.comet.ml/alexrey88/omnigan/8af1aa2ba8b847abbc66feb2465c2e6f?experiment-tab=images&imageId=9f33d1ee56344059b698f4a390f03fe4)