### PR TITLE
WGAN in advent (This PR also includes the former compare loss which is now GroundIntersectionLoss)

### DIFF
--- a/entropy_cal.py
+++ b/entropy_cal.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from argparse import ArgumentParser
 from omnigan.trainer import Trainer
 from torchvision import transforms as trsfs
-from omnigan.losses import entropy_loss_v2
+from omnigan.losses import MinentLoss
 import json
 from omnigan.utils import load_opts, flatten_opts
 
@@ -119,7 +119,9 @@ if __name__ == "__main__":
     transforms = [trsfs.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))]
 
     device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
-
+    entropy_loss_v2 = MinentLoss(
+        version=2, lambda_var=opts.train.lambdas.advent.ent_var
+    )
     # ----------------------------
     # -----  Iterate images  -----
     # ----------------------------

--- a/omnigan/discriminator.py
+++ b/omnigan/discriminator.py
@@ -319,9 +319,14 @@ class OmniDiscriminator(nn.ModuleDict):
                     raise Exception("This Discriminator is currently not supported!")
         if "s" in opts.tasks:
             if opts.gen.s.use_advent:
-                self["s"] = nn.ModuleDict(
-                    {"Advent": get_fc_discriminator(num_classes=11)}
-                )
+                if opts.dis.s.gan_type == "WGAN_norm":
+                    self["s"] = nn.ModuleDict(
+                        {"Advent": get_fc_discriminator(num_classes=1, use_norm=True)}
+                    )
+                else:
+                    self["s"] = nn.ModuleDict(
+                        {"Advent": get_fc_discriminator(num_classes=11, use_norm=False)}
+                    )
 
 
 def get_fc_discriminator(num_classes=2, ndf=64, use_norm=False):

--- a/omnigan/discriminator.py
+++ b/omnigan/discriminator.py
@@ -321,7 +321,7 @@ class OmniDiscriminator(nn.ModuleDict):
             if opts.gen.s.use_advent:
                 if opts.dis.s.gan_type == "WGAN_norm":
                     self["s"] = nn.ModuleDict(
-                        {"Advent": get_fc_discriminator(num_classes=1, use_norm=True)}
+                        {"Advent": get_fc_discriminator(num_classes=11, use_norm=True)}
                     )
                 else:
                     self["s"] = nn.ModuleDict(

--- a/omnigan/losses.py
+++ b/omnigan/losses.py
@@ -442,6 +442,7 @@ class GroundIntersectionLoss(nn.Module):
     def __call__(self, pred, pseudo_ground):
         return torch.mean(1.0 * ((pseudo_ground - pred) > 0.5))
 
+
 def prob_2_entropy(prob):
     """
     convert probabilistic prediction maps to weighted self-information maps
@@ -471,9 +472,17 @@ class CustomBCELoss(nn.Module):
 
 class ADVENTAdversarialLoss(nn.Module):
     """
-        The class is for calculating the advent loss.
-        It is used to indirectly shrink the domain gap between sim and real
+    The class is for calculating the advent loss.
+    It is used to indirectly shrink the domain gap between sim and real
+
+    _call_ function:
+    prediction: torch.tensor with shape of [bs,c,h,w]
+    target: int; domain label: 0 (sim) or 1 (real)
+    discriminator: the discriminator model tells if a tensor is from sim or real
+
+    output: the loss value of GANLoss
     """
+
     def __init__(self, opts, gan_type="GAN"):
         super().__init__()
         self.opts = opts
@@ -485,13 +494,6 @@ class ADVENTAdversarialLoss(nn.Module):
             raise NotImplementedError
 
     def __call__(self, prediction, target, discriminator):
-    """
-        prediction: torch.tensor with shape of [bs,c,h,w]
-        target: int; domain label: 0 (sim) or 1 (real)
-        discriminator: the discriminator model tells if a tensor is from sim or real
-
-        output: the loss value of GANLoss
-    """
         d_out = discriminator(prob_2_entropy(F.softmax(prediction, dim=1)))
         if self.opts.dis.m.architecture == "OmniDiscriminator":
             d_out = multiDiscriminatorAdapter(d_out, self.opts)

--- a/omnigan/losses.py
+++ b/omnigan/losses.py
@@ -396,7 +396,9 @@ def get_losses(opts, verbose, device=None):
         losses["G"]["tasks"]["s"] = {}
         losses["G"]["tasks"]["s"]["crossent"] = CrossEntropy()
         losses["G"]["tasks"]["s"]["minent"] = MinentLoss()
-        losses["G"]["tasks"]["s"]["advent"] = ADVENTAdversarialLoss(opts)
+        losses["G"]["tasks"]["s"]["advent"] = ADVENTAdversarialLoss(
+            opts, gan_type=opts.dis.s.gan_type
+        )
     if "m" in opts.tasks:
         losses["G"]["tasks"]["m"] = {}
         losses["G"]["tasks"]["m"]["bce"] = nn.BCELoss()
@@ -407,8 +409,10 @@ def get_losses(opts, verbose, device=None):
         else:
             losses["G"]["tasks"]["m"]["minent"] = MinentLoss()
         losses["G"]["tasks"]["m"]["tv"] = TVLoss()
-        losses["G"]["tasks"]["m"]["advent"] = ADVENTAdversarialLoss(opts)
-
+        losses["G"]["tasks"]["m"]["advent"] = ADVENTAdversarialLoss(
+            opts, gan_type=opts.dis.m.gan_type
+        )
+        losses["G"]["tasks"]["m"]["gi"] = GroundIntersectionLoss()
     # undistinguishable features loss
     # TODO setup a get_losses func to assign the right loss according to the yaml
     if opts.classifier.loss == "l1":
@@ -430,6 +434,14 @@ def get_losses(opts, verbose, device=None):
     return losses
 
 
+class GroundIntersectionLoss(nn.Module):
+    """
+    Penalize areas in ground seg but not in flood mask
+    """
+
+    def __call__(self, pred, pseudo_ground):
+        return torch.mean(1.0 * ((pseudo_ground - pred) > 0.5))
+
 def prob_2_entropy(prob):
     """
     convert probabilistic prediction maps to weighted self-information maps
@@ -441,7 +453,7 @@ def prob_2_entropy(prob):
 class CustomBCELoss(nn.Module):
     """
         The first argument is a tensor and the second arguement is an int.
-        There is no need to take simoid before calling this function.
+        There is no need to take sigmoid before calling this function.
     """
 
     def __init__(self):
@@ -459,20 +471,27 @@ class CustomBCELoss(nn.Module):
 
 class ADVENTAdversarialLoss(nn.Module):
     """
-        The first and second argument are tensor. The third argument is a discriminator model.
+        The class is for calculating the advent loss.
+        It is used to indirectly shrink the domain gap between sim and real
     """
-
-    def __init__(self, opts):
+    def __init__(self, opts, gan_type="GAN"):
         super().__init__()
         self.opts = opts
-        if opts.dis.m.gan_type == "GAN":
+        if gan_type == "GAN":
             self.loss = CustomBCELoss()
-        elif opts.dis.m.gan_type == "WGAN" or "WGAN_gp" or "WGAN_norm":
+        elif gan_type == "WGAN" or "WGAN_gp" or "WGAN_norm":
             self.loss = lambda x, y: -torch.mean(y * x + (1 - y) * (1 - x))
         else:
             raise NotImplementedError
 
-    def __call__(self, prediction, target, discriminator, need_d_out=False):
+    def __call__(self, prediction, target, discriminator):
+    """
+        prediction: torch.tensor with shape of [bs,c,h,w]
+        target: int; domain label: 0 (sim) or 1 (real)
+        discriminator: the discriminator model tells if a tensor is from sim or real
+
+        output: the loss value of GANLoss
+    """
         d_out = discriminator(prob_2_entropy(F.softmax(prediction, dim=1)))
         if self.opts.dis.m.architecture == "OmniDiscriminator":
             d_out = multiDiscriminatorAdapter(d_out, self.opts)
@@ -480,7 +499,7 @@ class ADVENTAdversarialLoss(nn.Module):
         return loss_
 
 
-def multiDiscriminatorAdapter(d_out, opts):
+def multiDiscriminatorAdapter(d_out: list, opts: dict) -> torch.tensor:
     """
     Because the OmniDiscriminator does not directly return a tensor (but a list of tensor).
     Since there is no multilevel masker, the 0th tensor in the list is all we want.

--- a/omnigan/losses.py
+++ b/omnigan/losses.py
@@ -467,30 +467,12 @@ class ADVENTAdversarialLoss(nn.Module):
         self.opts = opts
         if opts.dis.m.gan_type == "GAN":
             self.loss = CustomBCELoss()
-        elif opts.dis.m.gan_type == "WGAN" or "WGAN_GP":
+        elif opts.dis.m.gan_type == "WGAN" or "WGAN_gp" or "WGAN_norm":
             self.loss = lambda x, y: -torch.mean(y * x + (1 - y) * (1 - x))
         else:
             raise NotImplementedError
 
     def __call__(self, prediction, target, discriminator, need_d_out=False):
-        d_out = discriminator(prob_2_entropy(F.softmax(prediction, dim=1)))
-        if self.opts.dis.m.architecture == "OmniDiscriminator":
-            d_out = multiDiscriminatorAdapter(d_out, self.opts)
-        loss_ = self.loss(d_out, target)
-        return loss_
-
-
-class ADVENTwganLoss(nn.Module):
-    """
-        The first and second argument are tensor. The third argument is a discriminator model.
-    """
-
-    def __init__(self, opts):
-        super().__init__()
-        self.opts = opts
-        self.loss = CustomBCELoss()
-
-    def __call__(self, prediction, target, discriminator):
         d_out = discriminator(prob_2_entropy(F.softmax(prediction, dim=1)))
         if self.opts.dis.m.architecture == "OmniDiscriminator":
             d_out = multiDiscriminatorAdapter(d_out, self.opts)

--- a/omnigan/optim.py
+++ b/omnigan/optim.py
@@ -2,7 +2,7 @@
 """
 import torch
 import math
-from torch.optim import Optimizer, Adam, lr_scheduler
+from torch.optim import Optimizer, Adam, lr_scheduler, RMSprop
 from torch_optimizer import NovoGrad, RAdam
 
 
@@ -100,6 +100,8 @@ def get_optimizer(net, opt_conf, tasks=None, iterations=-1):
         )  # default for beta2 is 0
     elif opt_conf.optimizer.lower() == "radam":
         opt = RAdam(params, lr=lr, betas=(opt_conf.beta1, 0.999))
+    elif opt_conf.optimizer.lower() == "rmsprop":
+        opt = RMSprop(params, lr=lr)
     else:
         opt = Adam(params, lr=lr, betas=(opt_conf.beta1, 0.999))
     scheduler = get_scheduler(opt, opt_conf, iterations)

--- a/omnigan/trainer.py
+++ b/omnigan/trainer.py
@@ -836,6 +836,7 @@ class Trainer:
                                     prediction,
                                     self.domain_labels["s"],
                                     self.D["s"]["Advent"],
+                                    gan_type=self.opts.dis.s.gan_type,
                                 )
                                 * lambdas.G[update_task]["advent"]
                             )
@@ -871,6 +872,21 @@ class Trainer:
                     self.logger.losses.gen.task["m"]["tv"][
                         batch_domain
                     ] = update_loss.item()
+
+                    # Then GroundIntersection loss
+                    if self.opts.gen.m.use_ground_intersection:
+                        if self.verbose > 0:
+                            print("Using GroundIntersection loss.")
+                        update_loss = (
+                            self.losses["G"]["tasks"][update_task]["gi"](
+                                prediction, update_target
+                            )
+                            * lambdas.G[update_task]["gi"]
+                        )
+                        step_loss += update_loss
+                        self.logger.losses.gen.task[update_task]["gi"][
+                            batch_domain
+                        ] = update_loss.item()
 
                     if batch_domain == "r":
                         pred_complementary = 1 - prediction
@@ -1179,6 +1195,7 @@ class Trainer:
                             prob.to(self.device),
                             self.domain_labels[batch_domain],
                             self.D["m"]["Advent"],
+                            gan_type=self.opts.dis.m.gan_type,
                         )
                         if self.opts.dis.m.gan_type == "GAN" or "WGAN_norm":
                             disc_loss["m"]["Advent"] += (
@@ -1221,6 +1238,7 @@ class Trainer:
                             preds.to(self.device),
                             self.domain_labels[batch_domain],
                             self.D["s"]["Advent"],
+                            gan_type=self.opts.dis.m.gan_type,
                         )
 
                         if self.opts.dis.s.gan_type == "GAN" or "WGAN_norm":

--- a/omnigan/trainer.py
+++ b/omnigan/trainer.py
@@ -1194,7 +1194,6 @@ class Trainer:
                             prob.to(self.device),
                             self.domain_labels[batch_domain],
                             self.D["m"]["Advent"],
-                            gan_type=self.opts.dis.m.gan_type,
                         )
                         if self.opts.dis.m.gan_type == "GAN" or "WGAN_norm":
                             disc_loss["m"]["Advent"] += (
@@ -1238,7 +1237,6 @@ class Trainer:
                             preds.to(self.device),
                             self.domain_labels[batch_domain],
                             self.D["s"]["Advent"],
-                            gan_type=self.opts.dis.m.gan_type,
                         )
 
                         if self.opts.dis.s.gan_type == "GAN" or "WGAN_norm":

--- a/omnigan/trainer.py
+++ b/omnigan/trainer.py
@@ -1368,7 +1368,7 @@ class Trainer:
 
         if not ("m" in self.opts.tasks and "p" in self.opts.tasks):
             self.g_opt.load_state_dict(checkpoint["g_opt"])
-        self.logger.epoch = checkpoint["epoch"]
+        self.logger.epoch = checkpoint["epoch"] + 1
         self.logger.global_step = checkpoint["step"]
 
         # resume scheduler:

--- a/omnigan/trainer.py
+++ b/omnigan/trainer.py
@@ -836,7 +836,6 @@ class Trainer:
                                     prediction,
                                     self.domain_labels["s"],
                                     self.D["s"]["Advent"],
-                                    gan_type=self.opts.dis.s.gan_type,
                                 )
                                 * lambdas.G[update_task]["advent"]
                             )

--- a/omnigan/trainer.py
+++ b/omnigan/trainer.py
@@ -873,19 +873,20 @@ class Trainer:
                     ] = update_loss.item()
 
                     # Then GroundIntersection loss
-                    if self.opts.gen.m.use_ground_intersection:
-                        if self.verbose > 0:
-                            print("Using GroundIntersection loss.")
-                        update_loss = (
-                            self.losses["G"]["tasks"][update_task]["gi"](
-                                prediction, update_target
+                    if batch_domain == "r":
+                        if self.opts.gen.m.use_ground_intersection:
+                            if self.verbose > 0:
+                                print("Using GroundIntersection loss.")
+                            update_loss = (
+                                self.losses["G"]["tasks"][update_task]["gi"](
+                                    prediction, update_target
+                                )
+                                * lambdas.G[update_task]["gi"]
                             )
-                            * lambdas.G[update_task]["gi"]
-                        )
-                        step_loss += update_loss
-                        self.logger.losses.gen.task[update_task]["gi"][
-                            batch_domain
-                        ] = update_loss.item()
+                            step_loss += update_loss
+                            self.logger.losses.gen.task[update_task]["gi"][
+                                batch_domain
+                            ] = update_loss.item()
 
                     if batch_domain == "r":
                         pred_complementary = 1 - prediction

--- a/omnigan/trainer.py
+++ b/omnigan/trainer.py
@@ -1180,7 +1180,7 @@ class Trainer:
                             self.domain_labels[batch_domain],
                             self.D["m"]["Advent"],
                         )
-                        if self.opts.dis.m.gan_type == "GAN":
+                        if self.opts.dis.m.gan_type == "GAN" or "WGAN_norm":
                             disc_loss["m"]["Advent"] += (
                                 self.opts.train.lambdas.advent.adv_main * loss_main
                             )

--- a/omnigan/trainer.py
+++ b/omnigan/trainer.py
@@ -1212,6 +1212,7 @@ class Trainer:
                         elif self.opts.dis.m.gan_type == "WGAN_gp":
                             prob_need_grad = autograd.Variable(prob, requires_grad=True)
                             d_out = self.D["m"]["Advent"](prob_need_grad)
+                            # github code reference: https://github.com/caogang/wgan-gp/blob/master/gan_cifar10.py
                             grads = autograd.grad(
                                 outputs=d_out,
                                 inputs=prob_need_grad,
@@ -1256,6 +1257,7 @@ class Trainer:
                         elif self.opts.dis.s.gan_type == "WGAN_gp":
                             prob_need_grad = autograd.Variable(prob, requires_grad=True)
                             d_out = self.D["s"]["Advent"](prob_need_grad)
+                            # github code reference: https://github.com/caogang/wgan-gp/blob/master/gan_cifar10.py
                             grads = autograd.grad(
                                 outputs=d_out,
                                 inputs=prob_need_grad,

--- a/omnigan/transforms.py
+++ b/omnigan/transforms.py
@@ -117,9 +117,13 @@ class ToTensor:
 
 
 class Normalize:
-    def __init__(self):
-        # self.normImage = trsfs.Normalize(([0.485, 0.456, 0.406], [0.229, 0.224, 0.225]))
-        self.normImage = trsfs.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))
+    def __init__(self, opts):
+        if opts.data.normalization == "default":
+            self.normImage = trsfs.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))
+        elif opts.data.normalization == "HRNet":
+            self.normImage = trsfs.Normalize(
+                ((0.485, 0.456, 0.406), (0.229, 0.224, 0.225))
+            )
         self.normDepth = lambda x: x  # trsfs.Normalize([1 / 255], [1 / 3])
         self.normMask = lambda x: x
         self.normSeg = lambda x: x
@@ -165,7 +169,7 @@ def get_transforms(opts):
     """Get all the transform functions listed in opts.data.transforms
     using get_transform(transform_item)
     """
-    last_transforms = [Normalize()]
+    last_transforms = [Normalize(opts)]
 
     conf_transforms = []
     for t in opts.data.transforms:

--- a/omnigan/tutils.py
+++ b/omnigan/tutils.py
@@ -391,7 +391,22 @@ def divide_pred(pred):
     return fake, real
 
 
-def get_WGAN_gradient(input, output):
+def is_tpu_available():
+    _torch_tpu_available = False
+    try:
+        import torch_xla.core.xla_model as xm  # noqa: F401
+
+        if "xla" in str(xm.xla_device()):
+            _torch_tpu_available = True  # pylint: disable=
+        else:
+            _torch_tpu_available = False
+    except ImportError:
+        _torch_tpu_available = False
+
+    return _torch_tpu_available
+
+  
+  def get_WGAN_gradient(input, output):
     # github code reference: https://github.com/caogang/wgan-gp/blob/master/gan_cifar10.py
     # Calculate the gradient that WGAN-gp needs
     grads = autograd.grad(

--- a/omnigan/tutils.py
+++ b/omnigan/tutils.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 # from copy import copy
 from threading import Thread
-
+from torch import autograd
 import numpy as np
 import torch
 from torch.autograd import Variable
@@ -389,3 +389,19 @@ def divide_pred(pred):
         real = pred[pred.size(0) // 2 :]
 
     return fake, real
+
+
+def get_WGAN_gradient(input, output):
+    # github code reference: https://github.com/caogang/wgan-gp/blob/master/gan_cifar10.py
+    # Calculate the gradient that WGAN-gp needs
+    grads = autograd.grad(
+        outputs=output,
+        inputs=input,
+        grad_outputs=torch.ones(output.size()).cuda(),
+        create_graph=True,
+        retain_graph=True,
+        only_inputs=True,
+    )[0]
+    grads = grads.view(grads.size(0), -1)
+    gp = ((grads.norm(2, dim=1) - 1) ** 2).mean()
+    return gp

--- a/omnigan/tutils.py
+++ b/omnigan/tutils.py
@@ -405,8 +405,8 @@ def is_tpu_available():
 
     return _torch_tpu_available
 
-  
-  def get_WGAN_gradient(input, output):
+
+def get_WGAN_gradient(input, output):
     # github code reference: https://github.com/caogang/wgan-gp/blob/master/gan_cifar10.py
     # Calculate the gradient that WGAN-gp needs
     grads = autograd.grad(

--- a/shared/trainer/defaults.yaml
+++ b/shared/trainer/defaults.yaml
@@ -165,7 +165,9 @@ dis:
     <<: *default-dis
     multi_level: false
     architecture: base # can be [base | OmniDiscriminator]
-
+    gan_type: GAN
+    wgan_clamp_lower: -0.01
+    wgan_clamp_upper: 0.01
 # -------------------------------
 # -----  Domain Classifier  -----
 # -------------------------------
@@ -221,6 +223,7 @@ train:
       adv_aux: 0.0 # the corresponding coefficient of the AdvEnt loss of second output
       dis_main: 0.5 # the discriminator take care of the first output in the adversarial training
       dis_aux: 0.5 # the discriminator take care of the second output in the adversarial training
+      WGAN_gp: 10
   log_level: 2 # 0: no log, 1: only aggregated losses, >1 detailed losses
   save_n_epochs: 1 # Save model every n epochs
   resume: false # Load latest_ckpt.pth checkpoint from `output_path` #TODO Make this path of checkpoint to load

--- a/shared/trainer/defaults.yaml
+++ b/shared/trainer/defaults.yaml
@@ -168,6 +168,10 @@ dis:
     gan_type: GAN
     wgan_clamp_lower: -0.01
     wgan_clamp_upper: 0.01
+  s:
+    gan_type: GAN
+    wgan_clamp_lower: -0.01
+    wgan_clamp_upper: 0.01
 # -------------------------------
 # -----  Domain Classifier  -----
 # -------------------------------

--- a/shared/trainer/defaults.yaml
+++ b/shared/trainer/defaults.yaml
@@ -168,11 +168,11 @@ dis:
     <<: *default-dis
     multi_level: false
     architecture: base # can be [base | OmniDiscriminator]
-    gan_type: GAN
+    gan_type: GAN_norm
     wgan_clamp_lower: -0.01
     wgan_clamp_upper: 0.01
   s:
-    gan_type: GAN
+    gan_type: GAN_norm
     wgan_clamp_lower: -0.01
     wgan_clamp_upper: 0.01
 # -------------------------------

--- a/shared/trainer/defaults.yaml
+++ b/shared/trainer/defaults.yaml
@@ -27,6 +27,9 @@ data:
   loaders:
     batch_size: 6
     num_workers: 8
+  normalization:
+    default # can be "default" or "HRNet" for now.
+    # default: mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5]; HRNet: mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]
   transforms:
     - name: hflip
       ignore: false
@@ -122,7 +125,7 @@ gen:
     use_minent: True # directly minimize the entropy of the image
     use_minent_var: True # add variance of entropy map in the measure of entropy for a certain picture
     use_advent: True # minimize the entropy of the image by adversarial training
-
+    use_ground_intersection: True
 # -------------------------
 # ----- Discriminator -----
 # -------------------------
@@ -209,6 +212,7 @@ train:
       m:
         bce: 1 # Main prediction loss, i.e. GAN or BCE
         tv: 1 # Total variational loss (for smoothing)
+        gi: 0.05
       p:
         gan: 1 # gan loss
         sm: 1 # semantic matching
@@ -225,8 +229,8 @@ train:
       ent_var: 0.1 # the proportion of variance of entropy map in the entropy measure for a certain picture
       adv_main: 1.0 # the coefficient of the AdvEnt loss that minimize the entropy of the image by adversarial training
       adv_aux: 0.0 # the corresponding coefficient of the AdvEnt loss of second output
-      dis_main: 0.5 # the discriminator take care of the first output in the adversarial training
-      dis_aux: 0.5 # the discriminator take care of the second output in the adversarial training
+      dis_main: 1.0 # the discriminator take care of the first output in the adversarial training
+      dis_aux: 0.0 # the discriminator take care of the second output in the adversarial training
       WGAN_gp: 10
   log_level: 2 # 0: no log, 1: only aggregated losses, >1 detailed losses
   save_n_epochs: 1 # Save model every n epochs


### PR DESCRIPTION
I added an option for ADVENT discriminator:

dis.m.gan_type now can be "GAN", "WGAN", "WGAN_gp", "WGAN_norm" and I added a "rmsprop" option for our optimizer which works for "WGAN" (Only "WGAN", not  "WGAN_gp" and "WGAN_norm").