### PR TITLE
Bring back Minent for segmentation head

### DIFF
--- a/omnigan/trainer.py
+++ b/omnigan/trainer.py
@@ -15,6 +15,7 @@ warnings.simplefilter("ignore", UserWarning)
 
 import torch
 import torchvision.utils as vutils
+import torch.nn.functional as F
 from torch import autograd
 from addict import Dict
 from comet_ml import Experiment
@@ -824,10 +825,11 @@ class Trainer:
                     if batch_domain == "r":
                         # Entropy minimization loss
                         if self.opts.gen.s.use_minent:
+                            softmax_preds = F.softmax(prediction, dim=1)
                             # Direct entropy minimization
                             update_loss = (
                                 self.losses["G"]["tasks"][update_task]["minent"](
-                                    prediction
+                                    softmax_preds
                                 )
                                 * lambdas.G[update_task]["minent"]
                             )

--- a/omnigan/trainer.py
+++ b/omnigan/trainer.py
@@ -17,7 +17,7 @@ warnings.simplefilter("ignore", UserWarning)
 import torch
 import torch.nn as nn
 import torchvision.utils as vutils
-
+from addict import Dict
 from comet_ml import Experiment
 from torch import autograd
 from tqdm import tqdm

--- a/omnigan/trainer.py
+++ b/omnigan/trainer.py
@@ -17,7 +17,6 @@ warnings.simplefilter("ignore", UserWarning)
 import torch
 import torch.nn as nn
 import torchvision.utils as vutils
-import torch.nn.functional as F
 
 from comet_ml import Experiment
 from torch import autograd
@@ -974,7 +973,7 @@ class Trainer:
                     if batch_domain == "r":
                         # Entropy minimization loss
                         if self.opts.gen.s.use_minent:
-                            softmax_preds = F.softmax(prediction, dim=1)
+                            softmax_preds = nn.functional.softmax(prediction, dim=1)
                             # Direct entropy minimization
                             update_loss = (
                                 self.losses["G"]["tasks"][update_task]["minent"](

--- a/shared/trainer/defaults.yaml
+++ b/shared/trainer/defaults.yaml
@@ -103,7 +103,7 @@ gen:
     num_classes: 11
     output_dim: 11
     use_advent: True
-    use_minent: False
+    use_minent: True
     use_pseudo_labels: False
     upsample_featuremaps: False # upsamples from 80x80 to 160x160 intermediate feature maps
   p: # specific params for the SPADE painter


### PR DESCRIPTION
Small modif to use minimization of entropy for segmentation head.
Diff experiment: [here](https://www.comet.ml/alexrey88/omnigan/8b4d029579ce4a46b28808f50f26568a/e4464d71cdc24a0eaf7b2eedacc76ba7/compare?experiment-tab=params)