### PR TITLE
Vkitti

### DIFF
--- a/apply_events.py
+++ b/apply_events.py
@@ -165,8 +165,8 @@ if __name__ == "__main__":
     # normalize to -1:1
     data = [(normalize(d.astype(np.float32)) - 0.5) * 2 for d in data]
     # half precision
-    if half:
-        data = [d.astype(np.float16) for d in data]
+    # if half:
+    #     data = [d.astype(np.float16) for d in data]
 
     n_batchs = len(data) // args.batch_size
     if len(data) % args.batch_size != 0:
@@ -191,7 +191,9 @@ if __name__ == "__main__":
             images = np.stack(images)
 
             # Retreive numpy events as a dict {event: array}
-            events = trainer.infer_all(images, True, stores, bin_value=bin_value)
+            events = trainer.infer_all(
+                images, True, stores, bin_value=bin_value, half=half
+            )
 
             # store events to write after inference loop
             all_events.append(events)

--- a/omnigan/blocks.py
+++ b/omnigan/blocks.py
@@ -623,6 +623,25 @@ class PainterSpadeDecoder(nn.Module):
 
         self.upsample = InterpolateNearest2d(scale_factor=2)
 
+    def set_latent_shape(self, shape, is_input=True):
+        """
+        Sets the latent shape to start the upsampling from, i.e. z_h and z_w.
+        If is_input is True, then this is the actual input shape which should
+        be divided by 2 ** spade_n_up
+        Otherwise, just sets z_h and z_w from shape[-2] and shape[-1]
+
+        Args:
+            shape (tuple): The shape to start sampling from.
+            is_input (bool, optional): Whether to divide shape by 2 ** spade_n_up
+        """
+
+        self.z_h = shape[-2]
+        self.z_w = shape[-1]
+
+        if is_input:
+            self.z_h = self.z_h // (2 ** self.opts.gen.p.spade_n_up)
+            self.z_w = self.z_w // (2 ** self.opts.gen.p.spade_n_up)
+
     def _apply(self, fn):
         # print("Applying SpadeDecoder", fn)
         super()._apply(fn)

--- a/omnigan/blocks.py
+++ b/omnigan/blocks.py
@@ -639,8 +639,8 @@ class PainterSpadeDecoder(nn.Module):
         self.z_w = shape[-1]
 
         if is_input:
-            self.z_h = self.z_h // (2 ** self.opts.gen.p.spade_n_up)
-            self.z_w = self.z_w // (2 ** self.opts.gen.p.spade_n_up)
+            self.z_h = self.z_h // (2 ** self.spade_n_up)
+            self.z_w = self.z_w // (2 ** self.spade_n_up)
 
     def _apply(self, fn):
         # print("Applying SpadeDecoder", fn)

--- a/omnigan/blocks.py
+++ b/omnigan/blocks.py
@@ -413,7 +413,6 @@ class DepthDecoder(nn.Module):
                     nn.Conv2d(128, 32, kernel_size=3, stride=1, padding=1),
                     nn.ReLU(True),
                     nn.Conv2d(32, 1, kernel_size=1, stride=1, padding=0),
-                    nn.ReLU(True),
                 ]
             )
         if isinstance(opts.data.transforms[-1].new_size, int):

--- a/omnigan/data.py
+++ b/omnigan/data.py
@@ -49,7 +49,121 @@ classes_dict = {
         9: [8, 19, 49, 255],  # Sky
         10: [0, 80, 100, 255],  # Default
     },
+    "kitti": {
+        0: [210, 0, 200],  # Terrain
+        1: [90, 200, 255],  # Sky
+        2: [0, 199, 0],  # Tree
+        3: [90, 240, 0],  # Vegetation
+        4: [140, 140, 140],  # Building
+        5: [100, 60, 100],  # Road
+        6: [250, 100, 255],  # GuardRail
+        7: [255, 255, 0],  # TrafficSign
+        8: [200, 200, 0],  # TrafficLight
+        9: [255, 130, 0],  # Pole
+        10: [80, 80, 80],  # Misc
+        11: [160, 60, 60],  # Truck
+        12: [255, 127, 80],  # Car
+        13: [0, 139, 139],  # Van
+        14: [0, 0, 0],  # Undefined
+    },
 }
+
+kitti_mapping = {
+    0: 5,  # Terrain -> Terrain
+    1: 9,  # Sky -> Sky
+    2: 7,  # Tree -> Trees
+    3: 4,  # Vegetation ->  Vegetation
+    4: 2,  # Building -> Building
+    5: 1,  # Road -> Ground
+    6: 3,  # GuardRail -> Traffic items
+    7: 3,  # TrafficSign ->  Traffic items
+    8: 3,  # TrafficLight -> Traffic items
+    9: 3,  # Pole -> Traffic items
+    10: 10,  # Misc -> default
+    11: 6,  # Truck -> Car
+    12: 6,  # Car -> Car
+    13: 6,  # Van -> Car
+    14: 10,  # Undefined -> Default
+}
+
+
+def merge_labels(labels, mapping, default_value=14):
+    """
+    Maps values in `labels` to those of mapping, assigning new labels
+    to each pixel
+
+    Args:
+        labels (np.ndarray): Labels to adapt
+        mapping (dict): Mapping source_label -> target_label (kitti->omnigan)
+        default_value (int, optional): Value for unknown labels. Defaults to 14.
+
+    Returns:
+        np.ndarray: adapted labels
+    """
+    out = np.ones_like(labels) * default_value
+    for source, target in mapping.items():
+        out[labels == source] = target
+    return out
+
+
+def encode_exact_segmap(seg, classes_dict, default_value=14):
+    """
+    When the mapping (rgb -> label) is known to be exact (no approximative rgb values)
+    maps rgb image to segmap labels
+
+    Args:
+        seg (np.ndarray): H x W x 3 RGB image
+        classes_dict (dict): Mapping {class: rgb value}
+        default_value (int, optional): Value for unknown label. Defaults to 14.
+
+    Returns:
+        np.ndarray: Segmap as labels, not RGB
+    """
+    out = np.ones((seg.shape[0], seg.shape[1])) * default_value
+    for cindex, cvalue in classes_dict.items():
+        out[np.where((seg == cvalue).all(-1))] = cindex
+    return out
+
+
+def merge_labels(labels, mapping, default_value=14):
+    """
+    Maps labels from a source domain to labels of a target domain,
+    typically kitti -> omnigan
+
+    Args:
+        labels (np.ndarray): input segmap labels
+        mapping (dict): source_label -> target_label
+        default_value (int, optional): Unknown label. Defaults to 14.
+
+    Returns:
+        np.ndarray: Adapted labels
+    """
+    out = np.ones_like(labels) * default_value
+    for source, target in mapping.items():
+        out[labels == source] = target
+    return out
+
+
+def process_kitti_seg(path, kitti_classes, merge_map, default=14):
+    """
+    Processes a path to produce a 1 x 1 x H x W torch segmap
+
+    %timeit process_kitti_seg(path, classes_dict, mapping, default=14)
+    326 ms ± 118 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
+
+    Args:
+        path (str | pathlib.Path): Segmap RBG path
+        kitti_classes (dict): Kitti map label -> rgb
+        merge_map (dict): map kitti_label -> omnigan_label
+        default (int, optional): Unknown kitti label. Defaults to 14.
+
+    Returns:
+        torch.Tensor: 1 x 1 x H x W torch segmap
+    """
+    seg = imread(path)
+    labels = encode_exact_segmap(seg, kitti_classes, default_value=default)
+    merged = merge_labels(labels, merge_map, default_value=default)
+    return torch.tensor(merged).unsqueeze(0).unsqueeze(0)
 
 
 def decode_segmap_merged_labels(tensor, domain, is_target, nc=11):
@@ -242,17 +356,21 @@ def tensor_loader(path, task, domain):
         [Tensor]: 1 x C x H x W
     """
     if task == "s":
-        arr = torch.load(path)
-        return arr
+        if domain == "kitti":
+            return process_kitti_seg(
+                path, classes_dict["kitti"], kitti_mapping, default=14
+            )
+        return torch.load(path)
     elif task == "d":
         if Path(path).suffix == ".npy":
             arr = np.load(path)
         else:
-            arr = imread(path)  # .astype(np.uint8)
-        arr = torch.from_numpy(arr.astype(np.float32))
-        arr = get_normalized_depth_t(arr, domain, normalize=True)
-        arr = arr.unsqueeze(0)
-        return arr
+            arr = imread(path)  # .astype(np.uint8) /!\ kitti is np.uint16
+        tensor = torch.from_numpy(arr.astype(np.float32))
+        tensor = get_normalized_depth_t(tensor, domain, normalize=True)
+        tensor = tensor.unsqueeze(0)
+        return tensor
+
     elif Path(path).suffix == ".npy":
         arr = np.load(path).astype(np.float32)
     elif is_image_file(path):
@@ -277,10 +395,7 @@ def tensor_loader(path, task, domain):
         if len(arr.shape) >= 3:
             arr = arr[:, :, 0]
         arr = np.expand_dims(arr, 0)
-
-    # print(path)
-    # print(task)
-    # print(torch.from_numpy(arr).unsqueeze(0).shape)
+        
     return torch.from_numpy(arr).unsqueeze(0)
 
 

--- a/omnigan/data.py
+++ b/omnigan/data.py
@@ -395,7 +395,7 @@ def tensor_loader(path, task, domain):
         if len(arr.shape) >= 3:
             arr = arr[:, :, 0]
         arr = np.expand_dims(arr, 0)
-        
+
     return torch.from_numpy(arr).unsqueeze(0)
 
 
@@ -471,7 +471,7 @@ class OmniListDataset(Dataset):
                 }
             ),
             "paths": paths,
-            "domain": self.domain,
+            "domain": self.domain if self.domain != "kitti" else "s",
             "mode": self.mode,
         }
 

--- a/omnigan/logger.py
+++ b/omnigan/logger.py
@@ -26,6 +26,9 @@ class Logger:
         all_legends = ["Input"]
         task_legends = {}
 
+        if domain not in trainer.display_images[mode]:
+            return
+
         # --------------------
         # -----  Masker  -----
         # --------------------
@@ -341,7 +344,9 @@ class Logger:
             )
 
             if header is not None:
-                image_grid = torch.cat([header.to(image_grid.device), image_grid], dim=1)
+                image_grid = torch.cat(
+                    [header.to(image_grid.device), image_grid], dim=1
+                )
 
             image_grid = image_grid.permute(1, 2, 0).cpu().numpy()
             trainer.exp.log_image(

--- a/omnigan/logger.py
+++ b/omnigan/logger.py
@@ -34,7 +34,6 @@ class Logger:
         # --------------------
         if domain != "rf":
             for j, display_dict in enumerate(trainer.display_images[mode][domain]):
-                print(j, end="\r")
                 x = display_dict["data"]["x"].unsqueeze(0).to(trainer.device)
                 z = trainer.G.encode(x)
 

--- a/omnigan/logger.py
+++ b/omnigan/logger.py
@@ -40,6 +40,9 @@ class Logger:
                     if task == "p":
                         continue
 
+                    if task not in display_dict["data"]:
+                        continue
+
                     task_legend = ["Input"]
                     target = display_dict["data"][task]
                     target = target.unsqueeze(0).to(trainer.device)

--- a/omnigan/trainer.py
+++ b/omnigan/trainer.py
@@ -516,9 +516,13 @@ class Trainer:
             tuple: (c, h, w)
         """
         x = None
-        for mode in self.loaders:
-            for domain in self.loaders[mode]:
-                x = self.loaders[mode][domain].dataset[0]["data"]["x"].to(self.device)
+        for mode in self.all_loaders:
+            for domain in all_loaders.loaders[mode]:
+                x = (
+                    self.all_loaders[mode][domain]
+                    .dataset[0]["data"]["x"]
+                    .to(self.device)
+                )
                 break
             if x is not None:
                 break
@@ -723,7 +727,7 @@ class Trainer:
         self.losses = get_losses(self.opts, verbose, device=self.device)
 
         if verbose > 0:
-            for mode, mode_dict in self.loaders.items():
+            for mode, mode_dict in self.all_loaders.items():
                 for domain, domain_loader in mode_dict.items():
                     print(
                         "Loader {} {} : {}".format(
@@ -734,14 +738,14 @@ class Trainer:
         # ----------------------------
         # -----  Display images  -----
         # ----------------------------
-        for mode, mode_dict in self.loaders.items():
+        for mode, mode_dict in self.all_loaders.items():
             self.display_images[mode] = {}
             for domain, domain_loader in mode_dict.items():
                 if self.kitti_pretrain and domain == "kitti":
                     target_dict = self.kitty_display_images
                 else:
                     target_dict = self.base_display_images
-                dataset = self.loaders[mode][domain].dataset
+                dataset = self.all_loaders[mode][domain].dataset
                 display_indices = get_display_indices(self.opts, domain, len(dataset))
                 ldis = len(display_indices)
                 print(

--- a/omnigan/trainer.py
+++ b/omnigan/trainer.py
@@ -517,7 +517,7 @@ class Trainer:
         """
         x = None
         for mode in self.all_loaders:
-            for domain in all_loaders.loaders[mode]:
+            for domain in self.all_loaders.loaders[mode]:
                 x = (
                     self.all_loaders[mode][domain]
                     .dataset[0]["data"]["x"]

--- a/omnigan/trainer.py
+++ b/omnigan/trainer.py
@@ -209,7 +209,7 @@ class Trainer:
             print(*args, **kwargs)
 
     @torch.no_grad()
-    def infer_all(self, x, numpy=True, stores={}, bin_value=-1):
+    def infer_all(self, x, numpy=True, stores={}, bin_value=-1, half=False):
         """
         Create a dictionnary of events from a numpy or tensor,
         single or batch image data.
@@ -241,6 +241,9 @@ class Trainer:
         # interpolate to standard input size
         if x.shape[-1] != 640 or x.shape[-2] != 640:
             x = torch.nn.functional.interpolate(x, (640, 640), mode="bilinear")
+
+        if half:
+            x = x.half()
 
         # encode
         with Timer(store=stores.get("encode", [])):

--- a/omnigan/trainer.py
+++ b/omnigan/trainer.py
@@ -547,10 +547,10 @@ class Trainer:
         else:
             domain = "rf"
 
-        if "train" in self.loaders:
+        if "train" in self.all_loaders:
             mode = "train"
         else:
-            assert "val" in self.loaders, "no data loader found"
+            assert "val" in self.all_loaders, "no data loader found"
             mode = "val"
 
         return {

--- a/omnigan/trainer.py
+++ b/omnigan/trainer.py
@@ -1626,7 +1626,7 @@ class Trainer:
         print("****************** Done in {}s *********************".format(timing))
 
     def eval_images(self, mode, domain):
-        if domain == "rf":
+        if domain == "rf" or domain not in self.display_images[mode]:
             return
 
         metric_funcs = {"accuracy": accuracy, "mIOU": mIOU}

--- a/omnigan/trainer.py
+++ b/omnigan/trainer.py
@@ -99,6 +99,7 @@ class Trainer:
 
         self.current_mode = "train"
         self.kitti_pretrain = self.opts.train.kitti.pretrain
+        self.use_pseudo_labels = self.opts.train.pseudo.enable
 
         self.lr_names = {}
         self.base_display_images = {}
@@ -827,6 +828,9 @@ class Trainer:
                 self.switch_data(to="base")
                 self.kitti_pretrain = False
 
+            if self.logger.epoch == self.opts.train.pseudo.epochs - 1:
+                self.use_pseudo_labels = False
+
     def run_epoch(self):
         """Runs an epoch:
         * checks trainer is setup
@@ -1332,7 +1336,7 @@ class Trainer:
         if weight == 0:
             return full_loss
 
-        if domain == "r" and not self.opts.gen.d.use_pseudo_labels:
+        if domain == "r" and not self.use_pseudo_labels:
             return full_loss
 
         # -------------------
@@ -1364,7 +1368,7 @@ class Trainer:
         # Supervised segmentation loss: crossent for sim domain,
         # crossent_pseudo for real ; loss is crossent in any case
         if for_ == "G":
-            if domain == "s" or self.opts.gen.s.use_pseudo_labels:
+            if domain == "s" or self.use_pseudo_labels:
                 if domain == "s":
                     logger = self.logger.losses.gen.task["s"]["crossent"]
                     weight = self.opts.train.lambdas.G["s"]["crossent"]

--- a/omnigan/trainer.py
+++ b/omnigan/trainer.py
@@ -98,7 +98,7 @@ class Trainer:
         self.exp = None
 
         self.current_mode = "train"
-        self.kitti_pretrain = self.opts.kitti.pretrain
+        self.kitti_pretrain = self.opts.train.kitti.pretrain
 
         self.lr_names = {}
         self.base_display_images = {}
@@ -749,6 +749,8 @@ class Trainer:
                 if self.kitti_pretrain and domain == "kitti":
                     target_dict = self.kitty_display_images
                 else:
+                    if domain == "kitti":
+                        continue
                     target_dict = self.base_display_images
 
                 dataset = self.all_loaders[mode][domain].dataset

--- a/omnigan/trainer.py
+++ b/omnigan/trainer.py
@@ -739,12 +739,18 @@ class Trainer:
         # -----  Display images  -----
         # ----------------------------
         for mode, mode_dict in self.all_loaders.items():
-            self.display_images[mode] = {}
+
+            if self.kitti_pretrain:
+                self.kitty_display_images[mode] = {}
+            self.base_display_images[mode] = {}
+
             for domain, domain_loader in mode_dict.items():
+
                 if self.kitti_pretrain and domain == "kitti":
                     target_dict = self.kitty_display_images
                 else:
                     target_dict = self.base_display_images
+
                 dataset = self.all_loaders[mode][domain].dataset
                 display_indices = get_display_indices(self.opts, domain, len(dataset))
                 ldis = len(display_indices)
@@ -765,6 +771,8 @@ class Trainer:
 
         if self.kitti_pretrain:
             self.switch_data(to="kitti")
+        else:
+            self.switch_data(to="base")
 
         print(" " * 50, end="\r")
         print("Done creating display images")

--- a/omnigan/tutils.py
+++ b/omnigan/tutils.py
@@ -193,6 +193,11 @@ def get_normalized_depth_t(arr, domain, normalize=False):
     elif domain == "s":
         # from 3-channel depth encoding from Unity simulator to 1-channel [0-1] values
         arr = decode_unity_depth_t(arr, log=False, normalize=normalize)
+    elif domain == "kitti":
+        arr = 1 / arr
+        if normalize:
+            arr = arr - arr.min()
+            arr = arr / arr.max()
     return arr
 
 

--- a/omnigan/tutils.py
+++ b/omnigan/tutils.py
@@ -183,22 +183,23 @@ def normalize_tensor(t):
     return t
 
 
-def get_normalized_depth_t(arr, domain, normalize=False):
+def get_normalized_depth_t(tensor, domain, normalize=False):
     if domain == "r":
         # megadepth depth
-        arr = arr.unsqueeze(0)
+        tensor = tensor.unsqueeze(0)
         if normalize:
-            arr = arr - torch.min(arr)
-            arr = torch.true_divide(arr, torch.max(arr))
+            tensor = tensor - torch.min(tensor)
+            tensor = torch.true_divide(tensor, torch.max(tensor))
     elif domain == "s":
         # from 3-channel depth encoding from Unity simulator to 1-channel [0-1] values
-        arr = decode_unity_depth_t(arr, log=False, normalize=normalize)
+        tensor = decode_unity_depth_t(tensor, log=False, normalize=normalize)
     elif domain == "kitti":
-        arr = 1 / arr
+        tensor = 1 / tensor
         if normalize:
-            arr = arr - arr.min()
-            arr = arr / arr.max()
-    return arr
+            tensor = tensor - tensor.min()
+            tensor = tensor / tensor.max()
+        tensor = tensor.unsqueeze(0)
+    return tensor
 
 
 def decode_unity_depth_t(unity_depth, log=True, normalize=False, numpy=False, far=1000):

--- a/omnigan/tutils.py
+++ b/omnigan/tutils.py
@@ -194,7 +194,7 @@ def get_normalized_depth_t(tensor, domain, normalize=False):
         # from 3-channel depth encoding from Unity simulator to 1-channel [0-1] values
         tensor = decode_unity_depth_t(tensor, log=False, normalize=normalize)
     elif domain == "kitti":
-        tensor = 1 / tensor
+        tensor = 1 / (tensor / 100)
         if normalize:
             tensor = tensor - tensor.min()
             tensor = tensor / tensor.max()

--- a/omnigan/utils.py
+++ b/omnigan/utils.py
@@ -222,7 +222,9 @@ def set_data_paths(opts: Dict) -> Dict:
                 opts.data.files[mode][domain] = str(
                     Path(opts.data.files.base) / opts.data.files[mode][domain]
                 )
-            assert Path(opts.data.files[mode][domain]).exists()
+            assert Path(
+                opts.data.files[mode][domain]
+            ).exists(), "Cannot find {}".format(str(opts.data.files[mode][domain]))
 
     return opts
 

--- a/omnigan/utils.py
+++ b/omnigan/utils.py
@@ -137,6 +137,10 @@ def load_opts(
         opts.domains.append("rf")
     opts.domains = list(set(opts.domains))
 
+    if opts.train.kitti.pretrained:
+        assert "kitti" in opts.data.files.train
+        assert "kitti" in opts.data.files.val
+
     if "s" in opts.tasks:
         if opts.gen.encoder.architecture != opts.gen.s.architecture:
             print(
@@ -810,8 +814,8 @@ def text_to_array(text, width=640, height=40):
     try:
         font = ImageFont.truetype("UnBatang.ttf", 25)
     except OSError:
-        font = ImageFont.load_default() 
-        
+        font = ImageFont.load_default()
+
     d = ImageDraw.Draw(img)
     text_width, text_height = d.textsize(text)
     h = 40 // 2 - 3 * text_height // 2

--- a/omnigan/utils.py
+++ b/omnigan/utils.py
@@ -130,16 +130,20 @@ def load_opts(
     if commandline_opts is not None and isinstance(commandline_opts, dict):
         opts = Dict(merge(commandline_opts, opts))
 
+    if opts.train.kitti.pretrained:
+        assert "kitti" in opts.data.files.train
+        assert "kitti" in opts.data.files.val
+        assert opts.train.kitti.epochs > 0
+
     opts.domains = []
     if "m" in opts.tasks or "s" in opts.tasks:
         opts.domains.extend(["r", "s"])
     if "p" in opts.tasks:
         opts.domains.append("rf")
-    opts.domains = list(set(opts.domains))
+    if opts.train.kitti.pretrain:
+        opts.domains.append("kitti")
 
-    if opts.train.kitti.pretrained:
-        assert "kitti" in opts.data.files.train
-        assert "kitti" in opts.data.files.val
+    opts.domains = list(set(opts.domains))
 
     if "s" in opts.tasks:
         if opts.gen.encoder.architecture != opts.gen.s.architecture:

--- a/omnigan/utils.py
+++ b/omnigan/utils.py
@@ -257,6 +257,22 @@ def get_git_revision_hash() -> str:
         return str(e)
 
 
+def get_git_branch() -> str:
+    """Get current git branch name
+
+    Returns:
+        str: git branch name
+    """
+    try:
+        return (
+            subprocess.check_output(["git", "rev-parse", "--abbrev-ref", "HEAD"])
+            .decode()
+            .strip()
+        )
+    except Exception as e:
+        return str(e)
+
+
 def kill_job(id: Union[int, str]) -> None:
     subprocess.check_output(["scancel", str(id)])
 

--- a/shared/trainer/defaults.yaml
+++ b/shared/trainer/defaults.yaml
@@ -29,10 +29,12 @@ data:
       r: train_r_full.json
       s: train_s_full.json
       rf: train_rf.json
+      kitti: train_kitti.json
     val:
       r: val_r_full.json
       s: val_s_full.json
       rf: val_rf.json
+      kitti: val_kitti.json
   check_samples: False
   loaders:
     batch_size: 6
@@ -234,6 +236,9 @@ classifier:
 # ----- Train Params -----
 # ------------------------
 train:
+  kitti:
+    pretrain: False
+    epochs: 30
   amp: False
   epochs: 300
   fid:

--- a/shared/trainer/defaults.yaml
+++ b/shared/trainer/defaults.yaml
@@ -125,7 +125,6 @@ gen:
     output_dim: 1
     conv_norm: batch
     res_norm: batch
-    use_pseudo_labels: False
     loss: dada
     upsample_featuremaps: False # upsamples from 80x80 to 160x160 intermediate feature maps
   s: # specific params for the semantic segmentation decoder
@@ -134,7 +133,6 @@ gen:
     output_dim: 11
     use_advent: True
     use_minent: True
-    use_pseudo_labels: False
     architecture: "deeplabv3"
     upsample_featuremaps: False # upsamples from 80x80 to 160x160 intermediate feature maps
   p: # specific params for the SPADE painter
@@ -241,6 +239,9 @@ train:
     epochs: 30
     batch_size: 20
   amp: False
+  pseudo:
+    enable: False # True or False to use pseudo-labels as supervision signal
+    epochs: 30 # disable pseudo training after n epochs (set to -1 to never disable)
   epochs: 300
   fid:
     n_images: 57 # val_rf.json has 57 images

--- a/shared/trainer/defaults.yaml
+++ b/shared/trainer/defaults.yaml
@@ -1,4 +1,4 @@
-output_path: /network/tmp1/schmidtv/yb_runs/test_v1
+output_path: /miniscratch/_groups/ccai/trash
 # README on load_path
 # 1/ any path which leads to a dir will be loaded as `path / checkpoints / latest_ckpt.pth`
 # 2/ if you want to specify a specific checkpoint, it MUST be a `.pth` file
@@ -24,7 +24,7 @@ tasks: [d, s, m, p] # [p] [m, s, d]
 data:
   max_samples: -1 # -1 for all, otherwise set to an int to crop the training data size
   files: # if one is not none it will override the dirs location
-    base: /network/tmp1/ccai/data/omnigan/base/
+    base: /miniscratch/_groups/ccai/data/jsons
     train:
       r: train_r_full.json
       s: train_s_full.json

--- a/test_trainer.py
+++ b/test_trainer.py
@@ -247,7 +247,7 @@ if __name__ == "__main__":
             "train.kitti.pretrain": True,
             "train.kitti.epochs": 1,
             "domains": ["kitti", "r", "s"],
-            "train.kitti.batch_size": 4,
+            "train.kitti.batch_size": 2,
         },
     ]
 

--- a/test_trainer.py
+++ b/test_trainer.py
@@ -198,47 +198,47 @@ if __name__ == "__main__":
     # create scenario-specific variables with __key
     # ALWAYS specify a __doc key to describe your scenario
     test_scenarios = [
-        {"__use_comet": False, "__doc": "MSD no exp", "__verbose": 1},
-        {"__doc": "MSD with exp"},
+        {"__use_comet": False, "__doc": "MSD no exp", "__verbose": 1},  # 0
+        {"__doc": "MSD with exp"},  # 1
         {
-            "__doc": "MSD no exp upsample_featuremaps",
+            "__doc": "MSD no exp upsample_featuremaps",  # 2
             "__use_comet": False,
             "gen.d.upsample_featuremaps": True,
             "gen.s.upsample_featuremaps": True,
         },
-        {"tasks": ["p"], "domains": ["rf"], "__doc": "Painter"},
+        {"tasks": ["p"], "domains": ["rf"], "__doc": "Painter"},  # 3
         {
-            "__doc": "M no exp low level feats",
+            "__doc": "M no exp low level feats",  # 4
             "__use_comet": False,
             "gen.m.use_low_level_feats": True,
             "tasks": ["m"],
         },
         {
-            "__doc": "MSD no exp deeplabv2",
+            "__doc": "MSD no exp deeplabv2",  # 5
             "__use_comet": False,
             "gen.encoder.architecture": "deeplabv2",
             "gen.s.architecture": "deeplabv2",
         },
         {
-            "__doc": "MSDP no End-to-end",
+            "__doc": "MSDP no End-to-end",  # 6
             "domains": ["rf", "r", "s"],
             "tasks": ["m", "s", "d", "p"],
         },
         {
-            "__doc": "MSDP inference only no exp",
+            "__doc": "MSDP inference only no exp",  # 7
             "__inference": True,
             "__use_comet": False,
             "domains": ["rf", "r", "s"],
             "tasks": ["m", "s", "d", "p"],
         },
         {
-            "__doc": "MSDP with End-to-end",
+            "__doc": "MSDP with End-to-end",  # 8
             "__pl4m": True,
             "domains": ["rf", "r", "s"],
             "tasks": ["m", "s", "d", "p"],
         },
         {
-            "__doc": "Kitti pretrain",
+            "__doc": "Kitti pretrain",  # 9
             "train.epochs": 2,
             "train.kitti.pretrain": True,
             "train.kitti.epochs": 1,

--- a/test_trainer.py
+++ b/test_trainer.py
@@ -247,7 +247,7 @@ if __name__ == "__main__":
             "train.kitti.pretrain": True,
             "train.kitti.epochs": 1,
             "domains": ["kitti", "r", "s"],
-            "data.max_samples": 2 * base_opts.train.kitti.get("batch_size", 9),
+            "train.kitti.batch_size": 4,
         },
     ]
 

--- a/test_trainer.py
+++ b/test_trainer.py
@@ -146,8 +146,12 @@ if __name__ == "__main__":
 
     assert not (args.include and args.exclude), "Choose 1: include XOR exclude"
 
-    include = set(args.include)
-    exclude = set(args.exclude)
+    include = set(int(i) for i in args.include)
+    exclude = set(int(i) for i in args.exclude)
+    if include:
+        print("Including exclusively tests", " ".join(args.include))
+    if exclude:
+        print("Excluding tests", " ".join(args.exclude))
 
     # --------------------------------------
     # -----  Create global experiment  -----
@@ -256,6 +260,8 @@ if __name__ == "__main__":
 
     for test_idx, conf in enumerate(test_scenarios):
         if test_idx in exclude or (include and test_idx not in include):
+            reason = "because it is in exclude" if test_idx in exclude else "because it is not in include"
+            print("Ignoring test", test_idx, reason)
             continue
 
         # copy base scenario opts

--- a/test_trainer.py
+++ b/test_trainer.py
@@ -323,5 +323,5 @@ if __name__ == "__main__":
     if len(fails) == 0:
         print("•• All scenarios were successful")
     else:
-        print(f"•• {len(successes)} successful tests")
+        print(f"•• {len(successes)}/{len(test_scenarios)} successful tests")
         print(f"•• Failed test indices: {', '.join(map(str, fails))}")

--- a/test_trainer.py
+++ b/test_trainer.py
@@ -117,7 +117,7 @@ def print_end(desc=None, ok=None):
 
     title = "|  " + cdesc + "  |"
     line = "-" * (len(desc) + 6)
-    print(f"{line}\n{title}\n{line}")
+    print(f"{line}\n{title}\n{line}\n")
 
 
 def delete_on_exit(exp):
@@ -177,7 +177,7 @@ if __name__ == "__main__":
         input_shapes = {
             "x": (3, 256, 256),
             "s": (
-                base_opts.gen.s.num_classes, 
+                base_opts.gen.s.num_classes,
                 base_opts.data.transforms[-1].new_size.get("s", 256),
                 base_opts.data.transforms[-1].new_size.get("s", 256),
             ),
@@ -279,7 +279,8 @@ if __name__ == "__main__":
 
             # test training procedure
             trainer.setup(inference=inference)
-            trainer.train()
+            if not inference:
+                trainer.train()
 
             successes.append(test_idx)
             ok = True

--- a/test_trainer.py
+++ b/test_trainer.py
@@ -247,6 +247,7 @@ if __name__ == "__main__":
             "train.kitti.pretrain": True,
             "train.kitti.epochs": 1,
             "domains": ["kitti", "r", "s"],
+            "data.max_samples": 2 * base_opts.train.kitti.get("batch_size", 9),
         },
     ]
 

--- a/test_trainer.py
+++ b/test_trainer.py
@@ -246,6 +246,7 @@ if __name__ == "__main__":
             "train.epochs": 2,
             "train.kitti.pretrain": True,
             "train.kitti.epochs": 1,
+            "domains": ["kitti", "r", "s"],
         },
     ]
 
@@ -260,7 +261,11 @@ if __name__ == "__main__":
 
     for test_idx, conf in enumerate(test_scenarios):
         if test_idx in exclude or (include and test_idx not in include):
-            reason = "because it is in exclude" if test_idx in exclude else "because it is not in include"
+            reason = (
+                "because it is in exclude"
+                if test_idx in exclude
+                else "because it is not in include"
+            )
             print("Ignoring test", test_idx, reason)
             continue
 

--- a/train.py
+++ b/train.py
@@ -15,6 +15,7 @@ from omnigan.utils import (
     env_to_path,
     flatten_opts,
     get_git_revision_hash,
+    get_git_branch,
     get_increased_path,
     load_opts,
     copy_run_files,
@@ -89,6 +90,7 @@ def main(opts):
     copy_run_files(opts)
     # store git hash
     opts.git_hash = get_git_revision_hash()
+    opts.git_branch = get_git_branch()
 
     if not args.no_comet:
         # ----------------------------------
@@ -127,7 +129,7 @@ def main(opts):
 
         # Merge and log tags
         if args.comet_tags or opts.comet.tags:
-            tags = set()
+            tags = set([opts.git_branch])
             if args.comet_tags:
                 tags.update(args.comet_tags)
             if opts.comet.tags:

--- a/utils_scripts/make_vkitti2_jsons.py
+++ b/utils_scripts/make_vkitti2_jsons.py
@@ -7,7 +7,7 @@ import os
 def make_kitti_jsons(
     base,
     out_dir,
-    val_scene="/Scene05/",
+    val_scene="/Scene06/",
     keep_frames=[
         "15-deg-left",
         "15-deg-right",
@@ -77,7 +77,7 @@ if __name__ == "__main__":
     kitti_dir = "/miniscratch/_groups/ccai/data/vkitti2"
     out_dir = "/miniscratch/_groups/ccai/data/jsons"
 
-    val_scene_id = "/Scene05/"
+    val_scene_id = "/Scene06/"
 
     keep_frames = [
         "15-deg-left",

--- a/utils_scripts/make_vkitti2_jsons.py
+++ b/utils_scripts/make_vkitti2_jsons.py
@@ -1,0 +1,93 @@
+from pathlib import Path
+import json
+import datetime
+import os
+
+
+def make_kitti_jsons(
+    base,
+    out_dir,
+    val_scene="/Scene05/",
+    keep_frames=[
+        "15-deg-left",
+        "15-deg-right",
+        "30-deg-left",
+        "30-deg-right",
+        "clone",
+        "overcast",
+    ],
+):
+    """
+    https://europe.naverlabs.com/research/computer-vision/proxy-virtual-worlds-vkitti-2
+
+    SceneX/Y/frames/rgb/Camera_Z/rgb_%05d.jpg
+    SceneX/Y/frames/depth/Camera_Z/depth_%05d.png
+    SceneX/Y/frames/classsegmentation/Camera_Z/classgt_%05d.png
+    SceneX/Y/frames/instancesegmentation/Camera_Z/instancegt_%05d.png
+    SceneX/Y/frames/backwardFlow/Camera_Z/backwardFlow_%05d.png
+    SceneX/Y/frames/backwardSceneFlow/Camera_Z/backwardSceneFlow_%05d.png
+    SceneX/Y/frames/forwardFlow/Camera_Z/flow_%05d.png
+    SceneX/Y/frames/forwardSceneFlow/Camera_Z/sceneFlow_%05d.png
+    SceneX/Y/colors.txt
+    SceneX/Y/extrinsic.txt
+    SceneX/Y/intrinsic.txt
+    SceneX/Y/info.txt
+    SceneX/Y/bbox.txt
+    SceneX/Y/pose.txt
+
+    where X ∈ {01, 02, 06, 18, 20} and represent one of 5 different locations.
+    Y ∈ {15-deg-left, 15-deg-right, 30-deg-left, 30-deg-right, clone, fog, morning,
+        overcast, rain, sunset} and represent the different variations.
+    Z ∈ [0, 1] and represent the left (same as in virtual kitti) or right camera
+        (offset by 0.532725m to the right).
+
+    Note that our indexes always start from 0.
+    """
+
+    path = Path(base).resolve()
+    out = Path(out_dir).resolve()
+    out.mkdir(parents=True, exist_ok=True)
+    depths = (path / "depth").glob("**/*.png")
+    segs = (path / "segmentation").glob("**/*.png")
+    rgbs = (path / "rgb").glob("**/*.jpg")
+    train_data = []
+    val_data = []
+
+    for i, (x, s, d) in enumerate(zip(rgbs, segs, depths)):
+        if i % 100 == 0:
+            print(i, end="\r", flush=True)
+        item = {"x": str(x), "s": str(s), "d": str(d)}
+        if val_scene in str(x):
+            val_data.append(item)
+        else:
+            train_data.append(item)
+
+    with (out / "train_kitti.json").open("w") as f:
+        json.dump(train_data, f)
+    with (out / "val_kitti.json").open("w") as f:
+        json.dump(val_data, f)
+    with (out / "about_kitti_jsons.txt").open("w") as f:
+        f.write("{}: {}\n".format("val_scene", val_scene))
+        f.write("{}: {}\n".format("keep_frames", keep_frames))
+        f.write("Author: {}\n".format(os.environ.get("USER")))
+        f.write("Date: {}\n".format(str(datetime.datetime.now())))
+
+
+if __name__ == "__main__":
+    kitti_dir = "/miniscratch/_groups/ccai/data/vkitti2"
+    out_dir = "/miniscratch/_groups/ccai/data/jsons"
+
+    val_scene_id = "/Scene05/"
+
+    keep_frames = [
+        "15-deg-left",
+        "15-deg-right",
+        "30-deg-left",
+        "30-deg-right",
+        "clone",
+        "overcast",
+    ]
+
+    make_kitti_jsons(
+        kitti_dir, out_dir, val_scene=val_scene_id, keep_frames=keep_frames,
+    )

--- a/utils_scripts/make_vkitti2_jsons.py
+++ b/utils_scripts/make_vkitti2_jsons.py
@@ -8,7 +8,7 @@ def make_kitti_jsons(
     base,
     out_dir,
     val_scene="/Scene06/",
-    keep_frames=[
+    keep_variations=[
         "15-deg-left",
         "15-deg-right",
         "30-deg-left",
@@ -18,8 +18,6 @@ def make_kitti_jsons(
     ],
 ):
     """
-    https://europe.naverlabs.com/research/computer-vision/proxy-virtual-worlds-vkitti-2
-
     SceneX/Y/frames/rgb/Camera_Z/rgb_%05d.jpg
     SceneX/Y/frames/depth/Camera_Z/depth_%05d.png
     SceneX/Y/frames/classsegmentation/Camera_Z/classgt_%05d.png
@@ -36,26 +34,29 @@ def make_kitti_jsons(
     SceneX/Y/pose.txt
 
     where X ∈ {01, 02, 06, 18, 20} and represent one of 5 different locations.
-    Y ∈ {15-deg-left, 15-deg-right, 30-deg-left, 30-deg-right, clone, fog, morning,
-        overcast, rain, sunset} and represent the different variations.
-    Z ∈ [0, 1] and represent the left (same as in virtual kitti) or right camera
-        (offset by 0.532725m to the right).
-
+    Y ∈ {15-deg-left, 15-deg-right, 30-deg-left, 30-deg-right, clone, fog, morning, overcast, rain, sunset} and represent the different variations.
+    Z ∈ [0, 1] and represent the left (same as in virtual kitti) or right camera (offset by 0.532725m to the right).
     Note that our indexes always start from 0.
     """
 
     path = Path(base).resolve()
     out = Path(out_dir).resolve()
     out.mkdir(parents=True, exist_ok=True)
-    depths = (path / "depth").glob("**/*.png")
-    segs = (path / "segmentation").glob("**/*.png")
-    rgbs = (path / "rgb").glob("**/*.jpg")
+    depths = sorted((path / "depth").glob("**/*.png"))
+    segs = sorted((path / "segmentation").glob("**/*.png"))
+    rgbs = sorted((path / "rgb").glob("**/*.jpg"))
     train_data = []
     val_data = []
+    keep_variations = set(keep_variations)
 
     for i, (x, s, d) in enumerate(zip(rgbs, segs, depths)):
         if i % 100 == 0:
             print(i, end="\r", flush=True)
+
+        variation = x.parent.parent.parent.parent.name
+        if variation not in keep_variations:
+            continue
+
         item = {"x": str(x), "s": str(s), "d": str(d)}
         if val_scene in str(x):
             val_data.append(item)
@@ -68,7 +69,7 @@ def make_kitti_jsons(
         json.dump(val_data, f)
     with (out / "about_kitti_jsons.txt").open("w") as f:
         f.write("{}: {}\n".format("val_scene", val_scene))
-        f.write("{}: {}\n".format("keep_frames", keep_frames))
+        f.write("{}: {}\n".format("keep_variations", keep_variations))
         f.write("Author: {}\n".format(os.environ.get("USER")))
         f.write("Date: {}\n".format(str(datetime.datetime.now())))
 
@@ -77,9 +78,9 @@ if __name__ == "__main__":
     kitti_dir = "/miniscratch/_groups/ccai/data/vkitti2"
     out_dir = "/miniscratch/_groups/ccai/data/jsons"
 
-    val_scene_id = "/Scene06/"
+    val_scene_id = "/Scene02/"
 
-    keep_frames = [
+    keep_variations = [
         "15-deg-left",
         "15-deg-right",
         "30-deg-left",
@@ -89,5 +90,5 @@ if __name__ == "__main__":
     ]
 
     make_kitti_jsons(
-        kitti_dir, out_dir, val_scene=val_scene_id, keep_frames=keep_frames,
+        kitti_dir, out_dir, val_scene=val_scene_id, keep_variations=keep_variations,
     )


### PR DESCRIPTION
Add pretraining of the seg and depth heads on vkitti 2

## Data

* data is downloaded and extracted in `/miniscratch/_groups/ccai/data/vkitti2` (with an `about.txt` of course!)
* copied all exising jsons to `/miniscratch/_groups/ccai/data/jsons`
* put `train_kitti.json` and `val_kitti.json` there
* dataset is described there -> https://europe.naverlabs.com/research/computer-vision/proxy-virtual-worlds-vkitti-2/
* selected the entire `Scene02` as validation data
* Removed the `rain` `sunset` `fog` and `morning` variations

## Preprocessing

* added `data.py/process_kitti_seg()` function to parse and merge labels from the rgb png images of the segmentation maps
* depth is encoded as 1 px = 1cm so I just normalize the inverse depth in `tutils.py/get_normalized_depth_t()`
* input image is loaded as a regular `jpg` image

## Training

* I changed jsut a little the `trainer.py/setup()` interface with `self.all_loaders`, `self.kitty_display_images` and `self.base_display_images`
* Added a simple utility in the trainer `switch_data(self, to="kitti")` or `switch_data(self, to="base")` that changes `self.loaders` and `self.display_images` to point to either the kitti data or the base data  we are used to
* NOTHING changes in the rest of the code :) 
  * Except that we need to catch here and there potential mismatches between tasks and data keys (when pretraining with kitti, tasks are `msd` but in the pre-training phase there is no `m` data)

## Experiments

* I stopped [this one](https://www.comet.ml/vict0rsch/omnigan/d7b1eaab78c04c5da1ce1aa4c7c629dc?experiment-tab=chart&showOutliers=true&smoothing=0&transformY=smoothing&xAxis=step) but it shows the pre-training phase works
* [This one](https://www.comet.ml/vict0rsch/omnigan/e20bfefc76f84eacb01232f9f29042a2?experiment-tab=chart&showOutliers=true&smoothing=0&transformY=smoothing&xAxis=step) is running
* I added a test to check that everything works in `omnigan/test_trainer.py`