### PR TITLE
Include DADA

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ batch = Dict({
 | train_r_full_old.json, val_r_full_old.json     |   r    | MegaDepth+ Segmentation (HRNet + Cityscapes)                               |    ***    |
 | train_r_nopeople.json, val_r_nopeople.json     |   r    | Same training data as above with people removed                            |   Sasha   |
 | train_rf_with_sim.json                         |   rf   | Doubled train_rf's size with sim data  (randomly chosen)                   |  Victor   |
+| train_rf.json                                  |   rf   | UPDATE (12/12/20): added 50 ims & masks from ADE20K Outdoors               |  Victor   |
 
 
 

--- a/omnigan/blocks.py
+++ b/omnigan/blocks.py
@@ -453,7 +453,6 @@ class DADADepthRegressionDecoder(nn.Module):
         z4_enc = self.relu(z4_enc)
         z4_enc = self.enc4_3(z4_enc)
 
-        z_depth = None
         if self.do_feat_fusion:
             z_depth = self.dec4(z4_enc)
             z_depth = self.relu(z_depth)

--- a/omnigan/blocks.py
+++ b/omnigan/blocks.py
@@ -98,13 +98,13 @@ class Conv2dBlock(nn.Module):
 
         # initialize activation
         if activation == "relu":
-            self.activation = nn.ReLU(inplace=True)
+            self.activation = nn.ReLU(inplace=False)
         elif activation == "lrelu":
-            self.activation = nn.LeakyReLU(0.2, inplace=True)
+            self.activation = nn.LeakyReLU(0.2, inplace=False)
         elif activation == "prelu":
             self.activation = nn.PReLU()
         elif activation == "selu":
-            self.activation = nn.SELU(inplace=True)
+            self.activation = nn.SELU(inplace=False)
         elif activation == "tanh":
             self.activation = nn.Tanh()
         elif activation == "sigmoid":
@@ -494,7 +494,6 @@ class DADADepthRegressionDecoder(nn.Module):
         z_depth = None
         if self.do_feat_fusion:
             z_depth = self.dec4(z4_enc)
-            z_depth = self.relu(z_depth)
 
         if self.upsample is not None:
             z4_enc = self.upsample(z4_enc)

--- a/omnigan/blocks.py
+++ b/omnigan/blocks.py
@@ -484,6 +484,7 @@ class DADADepthRegressionDecoder(nn.Module):
         z4_enc = self.enc4_2(z4_enc)
         z4_enc = self.enc4_3(z4_enc)
 
+        z_depth = None
         if self.do_feat_fusion:
             z_depth = self.dec4(z4_enc)
             z_depth = self.relu(z_depth)
@@ -504,10 +505,7 @@ class DADADepthRegressionDecoder(nn.Module):
                 depth, (self.output_size, self.output_size), mode="nearest"
             )  # what we used in the transforms to resize input
 
-        if self.do_feat_fusion:
-            return depth, z_depth
-
-        return depth
+        return depth, z_depth
 
     def __str__(self):
         return "Depth_decoder"

--- a/omnigan/blocks.py
+++ b/omnigan/blocks.py
@@ -480,7 +480,8 @@ class DADADepthRegressionDecoder(nn.Module):
         return depth
 
     def __str__(self):
-        return strings.basedecoder(self)
+        return "Depth_decoder"
+        # return strings.basedecoder(self)
 
 
 # --------------------------

--- a/omnigan/blocks.py
+++ b/omnigan/blocks.py
@@ -411,8 +411,15 @@ class DADADepthRegressionDecoder(nn.Module):
         self.do_feat_fusion = False
         if "s" in opts.tasks and opts.gen.s.depth_feat_fusion:
             self.do_feat_fusion = True
-            self.dec4 = nn.Conv2d(
-                128, res_dim, kernel_size=1, stride=1, padding=0, bias=True
+            self.dec4 = Conv2dBlock(
+                128,
+                res_dim,
+                1,
+                stride=1,
+                padding=0,
+                bias=True,
+                activation="lrelu",
+                norm="none",
             )
 
         self.relu = nn.ReLU(inplace=True)

--- a/omnigan/deeplabv2.py
+++ b/omnigan/deeplabv2.py
@@ -187,7 +187,7 @@ class DeepLabV2Decoder(BaseDecoder):
         else:
             self._target_size = (size, size)
 
-    def forward(self, z):
+    def forward(self, z, z_depth=None):
         if self._target_size is None:
             error = "self._target_size should be set with self.set_target_size()"
             error += "to interpolate logits to the target seg map's size"
@@ -198,6 +198,8 @@ class DeepLabV2Decoder(BaseDecoder):
             raise Exception(
                 "Segmentation decoder will only work with 2048 channels for z"
             )
+        if z_depth is not None:
+            z = z * z_depth
         y = self.aspp(z)
         y = self.conv(y)
         return F.interpolate(y, self._target_size, mode="bilinear", align_corners=True)

--- a/omnigan/generator.py
+++ b/omnigan/generator.py
@@ -162,6 +162,9 @@ class OmniGenerator(nn.Module):
         return z
 
     def make_m_cond(self, d, s, x):
+        if self.opts.gen.m.spade.detach:
+            d = d.detach()
+            s = s.detach()
         cats = [normalize(d), softmax(s, dim=1)]
         if self.opts.gen.m.spade.cond_nc == 15:
             assert x is not None
@@ -180,7 +183,9 @@ class OmniGenerator(nn.Module):
         if cond is None and self.opts.gen.m.use_spade:
             assert "s" in self.opts.tasks and "d" in self.opts.tasks
             with torch.no_grad():
-                cond = self.make_m_cond(self.decoders["d"](z), self.decoders["s"](z), x)
+                d_pred, z_depth = self.decoders["d"](z)
+                s_pred = self.decoders["s"](z, z_depth)
+                cond = self.make_m_cond(d_pred, s_pred, x)
 
         if cond is not None:
             device = z[0].device if isinstance(z, (tuple, list)) else z.device

--- a/omnigan/generator.py
+++ b/omnigan/generator.py
@@ -319,9 +319,11 @@ class BaseDepthDecoder(BaseDecoder):
 
         d = super().forward(z)
 
-        return F.interpolate(
+        preds = F.interpolate(
             d, size=self._target_size, mode="bilinear", align_corners=True
         )
+
+        return preds, None
 
 
 class MaskSpadeDecoder(nn.Module):

--- a/omnigan/logger.py
+++ b/omnigan/logger.py
@@ -73,11 +73,10 @@ class Logger:
                     if task not in save_images:
                         save_images[task] = []
 
-                    if use_feat_fusion:
-                        if task == "d":
-                            prediction = depth_preds
-                        elif task == "s":
-                            prediction = trainer.G.decoders[task](z_feat_fusion)
+                    if use_feat_fusion and task == "d":
+                        prediction = depth_preds
+                    elif use_feat_fusion and task == "s":
+                        prediction = trainer.G.decoders[task](z_feat_fusion)
                     else:
                         prediction = trainer.G.decoders[task](z)
 

--- a/omnigan/logger.py
+++ b/omnigan/logger.py
@@ -73,10 +73,11 @@ class Logger:
                     if task not in save_images:
                         save_images[task] = []
 
-                    if task == "d" and use_feat_fusion:
-                        prediction = depth_preds
-                    elif task == "s" and use_feat_fusion:
-                        prediction = trainer.G.decoders[task](z_feat_fusion)
+                    if use_feat_fusion:
+                        if task == "d":
+                            prediction = depth_preds
+                        elif task == "s":
+                            prediction = trainer.G.decoders[task](z_feat_fusion)
                     else:
                         prediction = trainer.G.decoders[task](z)
 

--- a/omnigan/logger.py
+++ b/omnigan/logger.py
@@ -43,8 +43,7 @@ class Logger:
                 x = display_dict["data"]["x"].unsqueeze(0).to(trainer.device)
                 z = trainer.G.encode(x)
 
-                s_pred = decoded_s_pred = d_pred = None
-                z_feat_fusion = z_depth = None
+                s_pred = decoded_s_pred = d_pred = z_depth = None
                 for k, task in enumerate(["d", "s", "m"]):
 
                     if (
@@ -61,6 +60,7 @@ class Logger:
                     if task not in save_images:
                         save_images[task] = []
 
+                    prediction = None
                     if task == "m":
                         cond = None
                         if s_pred is not None and d_pred is not None:
@@ -69,12 +69,8 @@ class Logger:
                         prediction = trainer.G.decoders[task](z, cond)
                     elif task == "d":
                         prediction, z_depth = trainer.G.decoders[task](z)
-                        if z_depth is not None:
-                            z_feat_fusion = z * z_depth
-                    elif task == "s" and z_feat_fusion is not None:
-                        prediction = trainer.G.decoders[task](z_feat_fusion)
-                    else:
-                        prediction = trainer.G.decoders[task](z)
+                    elif task == "s":
+                        prediction = trainer.G.decoders[task](z, z_depth)
 
                     if task == "s":
                         # Log fire

--- a/omnigan/logger.py
+++ b/omnigan/logger.py
@@ -3,10 +3,9 @@ import torchvision.utils as vutils
 
 import numpy as np
 import torch
-from torch.nn.functional import sigmoid, interpolate, softmax
+from torch.nn.functional import sigmoid, interpolate
 from omnigan.data import decode_segmap_merged_labels
 from omnigan.tutils import (
-    normalize,
     normalize_tensor,
     all_texts_to_tensors,
     decode_bucketed_depth,

--- a/omnigan/losses.py
+++ b/omnigan/losses.py
@@ -512,7 +512,7 @@ class ADVENTAdversarialLoss(nn.Module):
         else:
             raise NotImplementedError
 
-    def __call__(self, prediction, target, discriminator):
+    def __call__(self, prediction, target, discriminator, depth_preds=None):
         """
         Compute the GAN loss from the Advent Discriminator given
         normalized (softmaxed) predictions (=pixel-wise class probabilities),
@@ -526,7 +526,10 @@ class ADVENTAdversarialLoss(nn.Module):
         Returns:
             torch.Tensor: float 0-D loss
         """
-        d_out = discriminator(prob_2_entropy(prediction))
+        d_out = prob_2_entropy(prediction)
+        if depth_preds is not None:
+            d_out = d_out * depth_preds
+        d_out = discriminator(d_out)
         if self.opts.dis.m.architecture == "OmniDiscriminator":
             d_out = multiDiscriminatorAdapter(d_out, self.opts)
         loss_ = self.loss(d_out, target)
@@ -603,8 +606,10 @@ class HingeLoss(nn.Module):
 
 
 class DADADepthLoss:
-    """
-    From https://github.com/valeoai/DADA/blob/master/dada/utils/func.py
+    """ Defines the reverse Huber loss from DADA paper for depth prediction
+        - Samples with larger residuals are penalized more by l2 term 
+        - Samples with smaller residuals are penalized more by l1 term
+        From https://github.com/valeoai/DADA/blob/master/dada/utils/func.py
     """
 
     def loss_calc_depth(self, pred, label):

--- a/omnigan/losses.py
+++ b/omnigan/losses.py
@@ -607,7 +607,7 @@ class HingeLoss(nn.Module):
 
 class DADADepthLoss:
     """ Defines the reverse Huber loss from DADA paper for depth prediction
-        - Samples with larger residuals are penalized more by l2 term 
+        - Samples with larger residuals are penalized more by l2 term
         - Samples with smaller residuals are penalized more by l1 term
         From https://github.com/valeoai/DADA/blob/master/dada/utils/func.py
     """

--- a/omnigan/losses.py
+++ b/omnigan/losses.py
@@ -379,7 +379,13 @@ def get_losses(opts, verbose, device=None):
     # painter losses
     if "p" in opts.tasks:
         losses["G"]["p"]["gan"] = (
-            HingeLoss() if opts.gen.p.loss == "hinge" else GANLoss()
+            HingeLoss()
+            if opts.gen.p.loss == "hinge"
+            else GANLoss(
+                use_lsgan=False,
+                soft_shift=opts.dis.soft_shift,
+                flip_prob=opts.dis.flip_prob,
+            )
         )
         losses["G"]["p"]["dm"] = MSELoss()
         losses["G"]["p"]["vgg"] = VGGLoss(device)

--- a/omnigan/trainer.py
+++ b/omnigan/trainer.py
@@ -1219,6 +1219,8 @@ class Trainer:
                         disc_loss["m"]["Advent"] += step_loss
 
                     if task == "s":
+                        depth_preds = None
+                        z_depth = None
                         if self.opts.gen.s.depth_dada_fusion:
                             depth_preds, z_depth = self.G.decoders["d"](z)
                         step_loss = self.masker_s_loss(

--- a/omnigan/trainer.py
+++ b/omnigan/trainer.py
@@ -1839,6 +1839,9 @@ class Trainer:
                         metric_avg_scores["d"][metric].append(metric_score)
 
             if "s" in metric_avg_scores:
+                if z_depth is None:
+                    if "d" in self.opts.tasks and self.opts.gen.s.depth_feat_fusion:
+                        _, z_depth = self.G.decoders["d"](z)
                 s_pred = self.G.decoders["s"](z, z_depth).detach().cpu()
                 s = im_set["data"]["s"].unsqueeze(0).detach()
 

--- a/omnigan/trainer.py
+++ b/omnigan/trainer.py
@@ -1301,6 +1301,8 @@ class Trainer:
             # -----  task-specific losses (2)  -----
             # --------------------------------------
             # Stored dict so that we compute depth before seg for DADA
+            depth_preds = None
+            z_depth = None
             for task, target in sorted(batch["data"].items()):
                 if task == "m":
                     loss = self.masker_m_loss(x, z, target, domain, "G")

--- a/omnigan/transforms.py
+++ b/omnigan/transforms.py
@@ -325,7 +325,7 @@ def get_transforms(opts, mode, domain):
     return transforms
 
 
-# --------- Adapted functions from https://github.com/mit-han-lab/data-efficient-gans ---------#
+# ----- Adapted functions from https://github.com/mit-han-lab/data-efficient-gans -----#
 def rand_brightness(tensor, is_diff_augment=False):
     if is_diff_augment:
         assert len(tensor.shape) == 4

--- a/shared/trainer/defaults.yaml
+++ b/shared/trainer/defaults.yaml
@@ -298,7 +298,7 @@ train:
 # ----- Validation Params -----
 # -----------------------------
 val:
-  visualize: false: # True if using visualizedEval.py to evaluate the masker. (Won't load any optimizers. Will load Generator state_dict unstrictly. Helpful to evaluate masker from multihead ckpt)
+  visualize: false # True if using visualizedEval.py to evaluate the masker. (Won't load any optimizers. Will load Generator state_dict unstrictly. Helpful to evaluate masker from multihead ckpt)
   store_images: false # write to disk on top of comet logging
 # -----------------------------
 # ----- Comet Params ----------

--- a/shared/trainer/defaults.yaml
+++ b/shared/trainer/defaults.yaml
@@ -140,6 +140,8 @@ gen:
     use_minent: True
     architecture: "deeplabv3"
     upsample_featuremaps: False # upsamples from 80x80 to 160x160 intermediate feature maps
+    depth_feat_fusion: True
+    depth_dada_fusion: True
   p: # specific params for the SPADE painter
     <<: *default-gen
     latent_dim: 512

--- a/shared/trainer/defaults.yaml
+++ b/shared/trainer/defaults.yaml
@@ -180,6 +180,7 @@ gen:
     n_res: 3
     use_low_level_feats: False
     spade:
+      detach: True # detach s_pred and d_pred conditionning tensors
       latent_dim: 256
       cond_nc: 12 # 12 without x, 15 with x
       spade_use_spectral_norm: True
@@ -267,7 +268,7 @@ train:
   amp: False
   pseudo:
     tasks: [] # list of tasks for which to use pseudo labels (empty list to disable)
-    epochs: 30 # disable pseudo training after n epochs (set to -1 to never disable)
+    epochs: 10 # disable pseudo training after n epochs (set to -1 to never disable)
   epochs: 300
   fid:
     n_images: 57 # val_rf.json has 57 images

--- a/visualizedEval.py
+++ b/visualizedEval.py
@@ -1,0 +1,190 @@
+from comet_ml import Experiment
+import torch
+from omnigan.utils import load_opts, flatten_opts
+from torch.nn.functional import sigmoid
+from pathlib import Path
+from argparse import ArgumentParser
+from omnigan.trainer import Trainer
+from omnigan.data import get_all_loaders, pil_image_loader
+from torchvision import transforms as trsfs
+import torchvision.utils as vutils
+
+
+def parsed_args():
+    """Parse and returns command-line args
+
+    Returns:
+        argparse.Namespace: the parsed arguments
+    """
+    parser = ArgumentParser()
+    parser.add_argument(
+        "--config",
+        default="./shared/trainer/defaults.yaml",
+        type=str,
+        help="What configuration file to use to overwrite default",
+    )
+    parser.add_argument(
+        "--default_config",
+        default="./shared/trainer/defaults.yaml",
+        type=str,
+        help="What default file to use",
+    )
+    parser.add_argument(
+        "--checkpoint",
+        default="/latest_ckpt.pth",
+        type=str,
+        help="Path to experiment folder containing checkpoints/latest_ckpt.pth",
+    )
+    parser.add_argument(
+        "--no_output", action="store_true", help="If you don't want to store images to output_dir"
+    )
+    parser.add_argument(
+        "--output_dir",
+        default="./output_masks/",
+        type=str,
+        help="Directory to write images to",
+    )
+    parser.add_argument(
+        "--image_domain",
+        default="r",
+        type=str,
+        help="Domain of images in path_to_images, can be 'r' or 's'",
+        required=True,
+    )
+    parser.add_argument(
+        "--valr_json",
+        default="/network/tmp1/ccai/data/omnigan/base/"
+        + "val_r_full_with_labelbox.json",
+        type=str,
+        help="The json file where you want to evaluate for real domain.",
+    )
+    parser.add_argument(
+        "--no_comet", action="store_true", help="DON'T use comet.ml to log experiment"
+    )
+    return parser.parse_args()
+
+
+def eval(trainer, opts, args):
+    save_images = {}
+    update_task = 'm' # only support masker evaluation now
+
+    for i, multi_batch_tuple in enumerate(trainer.val_loaders):
+        multi_domain_batch = {
+            batch["domain"][0]: trainer.batch_to_device(batch)
+            for batch in multi_batch_tuple
+        }
+        save_images[update_task] = []
+        j = 0
+        for batch_domain, batch in multi_domain_batch.items():
+            print("Evaluating {}th image".format(j))
+            j += 1
+            if batch_domain == args.image_domain:
+                file_name = batch["paths"]["m"][0].split("/")[-1]
+                x = batch["data"]["x"]
+                m = batch["data"]["m"]
+                z = model.encode(x)
+                mask = sigmoid(model.decoders[update_task](z))
+                mask = mask.repeat(1, 3, 1, 1)
+                task_saves = []
+
+                task_saves.append(x * (1.0 - mask))
+                task_saves.append(x * (1.0 - (mask > 0.1) * 1))
+                task_saves.append(x * (1.0 - (mask > 0.5) * 1))
+                task_saves.append(x * (1.0 - m.repeat(1, 3, 1, 1)))
+                task_saves.append(mask)
+                save_images[update_task].append(x)
+                for im in task_saves:
+                    save_images[update_task].append(im)
+                if not args.no_output:
+                    print("Saving image at {}".format(output_dir / file_name))
+                    vutils.save_image(mask, output_dir / file_name)
+        write_images(
+            trainer,
+            image_outputs=save_images[update_task],
+            file_name=file_name,
+            mode="val",
+            domain=args.image_domain,
+            task=update_task,
+            im_per_row=opts.comet.im_per_row.get(update_task, 6),
+            comet_exp=exp,
+        )
+
+
+def write_images(
+    trainer, image_outputs, file_name, mode, domain, task, im_per_row=3, comet_exp=None
+):
+    """Save output image
+    Arguments:
+        image_outputs {Tensor list} -- list of output images
+        im_per_row {int} -- number of images to be displayed (per row)
+        file_name {str} -- name of the file where to save the images
+    """
+    curr_iter = trainer.logger.global_step
+    image_outputs = torch.stack(image_outputs).squeeze()
+    image_grid = vutils.make_grid(
+        image_outputs, nrow=im_per_row, normalize=True, scale_each=True
+    )
+    image_grid = image_grid.permute(1, 2, 0).cpu().detach().numpy()
+
+    if comet_exp is not None:
+        comet_exp.log_image(
+            image_grid,
+            name=file_name + f"{mode}_{domain}_{task}_{str(curr_iter)}",
+            step=curr_iter,
+        )
+
+
+if __name__ == "__main__":
+    # -----------------------------
+    # -----  Parse arguments  -----
+    # -----------------------------
+
+    args = parsed_args()
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(exist_ok=True, parents=True)
+
+    # -----------------------
+    # -----  Load opts  -----
+    # -----------------------
+
+    opts = load_opts(Path(args.config), default="./shared/trainer/defaults.yaml")
+    opts.train.resume = True
+    if Path(args.checkpoint).suffix == '':
+        opts.output_path = str(Path(args.checkpoint).resolve())
+    elif Path(args.checkpoint).suffix.lower() == '.pth':
+        opt.load_paths.m = str(Path(args.checkpoint).resolve())
+        opts.output_path = "Loading a specific pth file, not using this option."
+    if args.image_domain == "r":
+        opts.data.files.val.r = args.valr_json
+        opts.data.files.train.r = opts.data.files.val.r
+        opts.data.files.train.s = opts.data.files.val.r
+        opts.data.files.val.s = opts.data.files.val.r
+    else:
+        opts.data.files.train.r = opts.data.files.val.s
+        opts.data.files.train.s = opts.data.files.val.s
+        opts.data.filesval.r = opts.data.files.val.s
+    opts.data.loaders.batch_size = 1
+    # opts.val.visualize = True
+    # ----------------------------------
+    # -----  Set Comet Experiment  -----
+    # ----------------------------------
+    exp = None
+    if not args.no_comet:
+        exp = Experiment(project_name="omnigan", auto_metric_logging=False)
+        exp.log_parameters(flatten_opts(opts))
+    # ------------------------
+    # ----- Define model -----
+    # ------------------------
+    print(args)
+    opts.data.loaders.batch_size = 1
+    opts.val.visualize = True
+    trainer = Trainer(opts)
+    print("Constructed a trainer!")
+    trainer.setup()
+    print("Trainer setup compelete!")
+    trainer.resume()
+    print("Trainer resumed!")
+    model = trainer.G
+    model.eval()
+    print("Model setting compelete!")
+    eval(trainer, opts, args)


### PR DESCRIPTION
Use approach from DADA paper to improve segmentation head, and thereby the masker.

Summary of changes:

- Feature fusion: features obtained from depth decoder, just before average pooling, are now passed through a small decoder to obtain an output of the same size as latent vector z , called `z_depth`. We then compute the element-wise product of latent vector z and `z_depth`. The resulting vector is given as input to the segmentation decoder.
- DADA fusion: the weighted self-information map of segmentation output is now multiplied by the depth output before being passed through the ADVENT discriminator of segmentation head. (Idea is that now, closer objects are given more attention).